### PR TITLE
Fix Wish Salamence ability set and standardize white space

### DIFF
--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -1,3 +1,6 @@
+using AutoModPlugins.GUI;
+using PKHeX.Core;
+using PKHeX.Core.Injection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -5,9 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using AutoModPlugins.GUI;
-using PKHeX.Core;
-using PKHeX.Core.Injection;
 
 namespace AutoModPlugins
 {
@@ -295,7 +295,7 @@ namespace AutoModPlugins
             {
                 pkm = SAV.SAV.GetDecryptedPKM(data);
             }
-            catch {}
+            catch { }
 
             bool valid = pkm is not null && pkm.Species <= pkm.MaxSpeciesID && pkm.ChecksumValid &&
                         ((pkm.Species == 0 && pkm.EncryptionConstant == 0) || (pkm.Species > 0 && pkm.Language != (int)LanguageID.Hacked && pkm.Language != (int)LanguageID.UNUSED_6));
@@ -698,7 +698,7 @@ namespace AutoModPlugins
                 // Invoke function
                 cc.GetType().GetMethod(v, BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(cc, new[] { s, e });
 
-                for (var i = 0; i <  objects.Count; i++)
+                for (var i = 0; i < objects.Count; i++)
                 {
                     if (objects[i] is not SCBlock scb)
                         write = true;

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using PKHeX.Core;
+using PKHeX.Core.AutoMod;
+using PKHeX.Core.Enhancements;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
-using PKHeX.Core;
-using PKHeX.Core.AutoMod;
-using PKHeX.Core.Enhancements;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/GUI/SimpleHexEditor.cs
+++ b/AutoLegalityMod/GUI/SimpleHexEditor.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using PKHeX.Core;
+using PKHeX.Core.Injection;
+using System;
 using System.Linq;
 using System.Timers;
 using System.Windows.Forms;
-using PKHeX.Core.Injection;
-using PKHeX.Core;
 
 namespace AutoModPlugins.GUI
 {
@@ -74,7 +74,8 @@ namespace AutoModPlugins.GUI
                         result = DecryptBlock(block_key, result)[headersize..];
                 }
                 var r_text = string.Join(" ", result.Select(z => $"{z:X2}"));
-                RTB_RAM.Invoke((MethodInvoker)delegate {
+                RTB_RAM.Invoke((MethodInvoker)delegate
+                {
                     if (RTB_RAM.Text != r_text) // Prevent text updates if there is no update since they hinder copying
                         RTB_RAM.Text = r_text;
                 });

--- a/AutoLegalityMod/GUI/WinFormsTranslator.cs
+++ b/AutoLegalityMod/GUI/WinFormsTranslator.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using AutoModPlugins.Properties;
+using PKHeX.Core;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using AutoModPlugins.Properties;
-using PKHeX.Core;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/AutoModPlugin.cs
+++ b/AutoLegalityMod/Plugins/AutoModPlugin.cs
@@ -1,3 +1,7 @@
+using AutoModPlugins.GUI;
+using AutoModPlugins.Properties;
+using PKHeX.Core;
+using PKHeX.Core.AutoMod;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,10 +11,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using AutoModPlugins.GUI;
-using AutoModPlugins.Properties;
-using PKHeX.Core;
-using PKHeX.Core.AutoMod;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/ExportBoxToShowdown.cs
+++ b/AutoLegalityMod/Plugins/ExportBoxToShowdown.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+using System;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/GPSSPlugin.cs
+++ b/AutoLegalityMod/Plugins/GPSSPlugin.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using AutoModPlugins.Properties;
+using PKHeX.Core;
+using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Windows.Forms;
-using AutoModPlugins.Properties;
-using PKHeX.Core;
 
 namespace AutoModPlugins
 {
@@ -15,9 +15,9 @@ namespace AutoModPlugins
 
         protected override void AddPluginControl(ToolStripDropDownItem modmenu)
         {
-            var ctrl = new ToolStripMenuItem(Name) {Name = "Menu_GPSSPlugin", Image = Resources.flagbrew};
-            var c1 = new ToolStripMenuItem("Upload to GPSS") {Image = Resources.uploadgpss};
-            var c2 = new ToolStripMenuItem("Import from GPSS URL") {Image = Resources.mgdbdownload};
+            var ctrl = new ToolStripMenuItem(Name) { Name = "Menu_GPSSPlugin", Image = Resources.flagbrew };
+            var c1 = new ToolStripMenuItem("Upload to GPSS") { Image = Resources.uploadgpss };
+            var c2 = new ToolStripMenuItem("Import from GPSS URL") { Image = Resources.mgdbdownload };
             c1.Click += GPSSUpload;
             c1.Name = "Menu_UploadtoGPSS";
             c2.Click += GPSSDownload;
@@ -70,10 +70,12 @@ namespace AutoModPlugins
                         msg = $"Pokemon added to the GPSS database. Here is your URL (has been copied to the clipboard):\n https://{Url}/gpss/{decoded["code"]}";
                         copyToClipboard = true;
                     }
-                } else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                }
+                else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
                 {
                     msg = "Uploading to GPSS is currently disabled, please try again later, or check the FlagBrew discord for more information.";
-                } else
+                }
+                else
                 {
                     msg = $"Uploading to GPSS returned an unexpected status code {response.StatusCode}\nError details (if any returned from server): {error}";
                 }
@@ -83,7 +85,8 @@ namespace AutoModPlugins
                     Clipboard.SetText($"https://{Url}/gpss/{decoded["code"]}");
                 }
                 WinFormsUtil.Alert(msg);
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 WinFormsUtil.Alert($"Something went wrong uploading to GPSS.\nError details: {ex.Message}");
             }

--- a/AutoLegalityMod/Plugins/LegalizeBoxes.cs
+++ b/AutoLegalityMod/Plugins/LegalizeBoxes.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Diagnostics;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+using System;
+using System.Diagnostics;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/LiveHex.cs
+++ b/AutoLegalityMod/Plugins/LiveHex.cs
@@ -1,7 +1,7 @@
-﻿using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.Injection;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/LivingDex.cs
+++ b/AutoLegalityMod/Plugins/LivingDex.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+using System;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/MGDBDownloader.cs
+++ b/AutoLegalityMod/Plugins/MGDBDownloader.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.Enhancements;
+using System;
+using System.IO;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {
@@ -39,7 +39,7 @@ namespace AutoModPlugins
                 "Selecting No will download only the public release of the database.");
 
             if (prompt == DialogResult.Cancel)
-              return;
+                return;
             var entire = prompt == DialogResult.Yes;
             EventsGallery.DownloadMGDBFromGitHub(MGDatabasePath, entire);
             WinFormsUtil.Alert("Download Finished");

--- a/AutoLegalityMod/Plugins/PKSMBankPlugin.cs
+++ b/AutoLegalityMod/Plugins/PKSMBankPlugin.cs
@@ -1,7 +1,7 @@
-﻿using System.IO;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core.Enhancements;
+using System.IO;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/PasteImporter.cs
+++ b/AutoLegalityMod/Plugins/PasteImporter.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using AutoModPlugins.Properties;
+using PKHeX.Core.Enhancements;
+using System;
 using System.IO;
 using System.Windows.Forms;
-using AutoModPlugins.Properties;
-using PKHeX.Core.Enhancements;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/SettingsEditor.cs
+++ b/AutoLegalityMod/Plugins/SettingsEditor.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Windows.Forms;
-using AutoModPlugins.GUI;
+﻿using AutoModPlugins.GUI;
 using AutoModPlugins.Properties;
+using System;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoLegalityMod/Plugins/SmogonGenner.cs
+++ b/AutoLegalityMod/Plugins/SmogonGenner.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Windows.Forms;
 using AutoModPlugins.Properties;
 using PKHeX.Core;
 using PKHeX.Core.Enhancements;
+using System;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {
@@ -14,7 +14,7 @@ namespace AutoModPlugins
 
         protected override void AddPluginControl(ToolStripDropDownItem modmenu)
         {
-            var ctrl = new ToolStripMenuItem(Name) {Name = "Menu_SmogonGenner", Image = Resources.smogongenner};
+            var ctrl = new ToolStripMenuItem(Name) { Name = "Menu_SmogonGenner", Image = Resources.smogongenner };
             modmenu.DropDownItems.Add(ctrl);
             ctrl.Click += SmogonGenning;
         }

--- a/AutoLegalityMod/Plugins/URLGenning.cs
+++ b/AutoLegalityMod/Plugins/URLGenning.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Windows.Forms;
-using AutoModPlugins.Properties;
+﻿using AutoModPlugins.Properties;
 using PKHeX.Core.Enhancements;
+using System;
+using System.Windows.Forms;
 
 namespace AutoModPlugins
 {

--- a/AutoModTests/FeatureMonitor.cs
+++ b/AutoModTests/FeatureMonitor.cs
@@ -1,6 +1,6 @@
-using System;
 using FluentAssertions;
 using PKHeX.Core.Enhancements;
+using System;
 using Xunit;
 
 namespace AutoModTests

--- a/AutoModTests/LegalityTests.cs
+++ b/AutoModTests/LegalityTests.cs
@@ -1,7 +1,7 @@
-using System.IO;
 using FluentAssertions;
 using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+using System.IO;
 using Xunit;
 
 namespace AutoModTests

--- a/AutoModTests/TeamTests.cs
+++ b/AutoModTests/TeamTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using FluentAssertions;
+using PKHeX.Core;
+using PKHeX.Core.AutoMod;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using FluentAssertions;
-using PKHeX.Core;
-using PKHeX.Core.AutoMod;
 using Xunit;
 using static PKHeX.Core.GameVersion;
 

--- a/AutoModTests/TestUtil.cs
+++ b/AutoModTests/TestUtil.cs
@@ -1,6 +1,6 @@
-﻿using System.IO;
-using PKHeX.Core;
+﻿using PKHeX.Core;
 using PKHeX.Core.AutoMod;
+using System.IO;
 
 namespace AutoModTests
 {

--- a/AutoModTests/WebSetFetch.cs
+++ b/AutoModTests/WebSetFetch.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Linq;
-using FluentAssertions;
+﻿using FluentAssertions;
 using PKHeX.Core;
 using PKHeX.Core.Enhancements;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace AutoModTests

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -94,12 +94,12 @@ namespace PKHeX.Core.AutoMod
                 }
 
                 // Look before we leap -- don't waste time generating invalid / incompatible junk.
-               if (!IsEncounterValid(set, enc, abilityreq, destVer))
-                   continue;
+                if (!IsEncounterValid(set, enc, abilityreq, destVer))
+                    continue;
 
-               if (enc is IFixedNature { IsFixedNature: true } fixedNature)
-                   criteria = criteria with { Nature = Nature.Random };
-                criteria = SetSpecialCriteria(criteria,enc, set);
+                if (enc is IFixedNature { IsFixedNature: true } fixedNature)
+                    criteria = criteria with { Nature = Nature.Random };
+                criteria = SetSpecialCriteria(criteria, enc, set);
                 // Create the PKM from the template.
                 var tr = SimpleEdits.IsUntradeableEncounter(enc) ? dest : GetTrainer(regen, enc.Version, enc.Generation);
                 var raw = enc.ConvertToPKM(tr, criteria);
@@ -125,14 +125,14 @@ namespace PKHeX.Core.AutoMod
 
                 // Transfer any VC1 via VC2, as there may be GSC exclusive moves requested.
                 if (dest.Generation >= 7 && raw is PK1 basepk1)
-                   raw = basepk1.ConvertToPK2();
+                    raw = basepk1.ConvertToPK2();
 
-                if (enc is EncounterTrade8b { Species: (ushort)Species.Magikarp})
+                if (enc is EncounterTrade8b { Species: (ushort)Species.Magikarp })
                 {
                     tr = set.Nickname switch
                     {
                         "ポッちゃん" => SaveUtil.GetBlankSAV(tr.Context, tr.OT, LanguageID.Japanese),
-                        "Bloupi" => SaveUtil.GetBlankSAV(tr.Context,tr.OT, LanguageID.French),
+                        "Bloupi" => SaveUtil.GetBlankSAV(tr.Context, tr.OT, LanguageID.French),
                         "Mossy" => SaveUtil.GetBlankSAV(tr.Context, tr.OT, LanguageID.Italian),
                         "Pador" => SaveUtil.GetBlankSAV(tr.Context, tr.OT, LanguageID.German),
                         _ => SaveUtil.GetBlankSAV(tr.Context, tr.OT, LanguageID.English)
@@ -293,7 +293,7 @@ namespace PKHeX.Core.AutoMod
 
                 GameVersion[] result;
                 if (value.IsValidSavedVersion())
-                    result = new GameVersion[] {value};
+                    result = new GameVersion[] { value };
                 else
                     result = GameUtil.GameVersions.Where(z => value.Contains(z)).ToArray();
 
@@ -364,7 +364,7 @@ namespace PKHeX.Core.AutoMod
         private static bool IsEncounterValid(IBattleTemplate set, IEncounterable enc, AbilityRequest abilityreq, GameVersion destVer)
         {
             // Don't process if encounter min level is higher than requested level
-            if(enc.Generation > 2)
+            if (enc.Generation > 2)
                 if (!IsRequestedLevelValid(set, enc))
                     return false;
 
@@ -530,7 +530,7 @@ namespace PKHeX.Core.AutoMod
             var language = regen.Extra.Language;
             var pidiv = MethodFinder.Analyze(pk);
             pk.SetPINGA(set, pidiv.Type, set.HiddenPowerType, enc);
-            pk.SetSpeciesLevel(set, Form, enc, handler,language);
+            pk.SetSpeciesLevel(set, Form, enc, handler, language);
             pk.SetDateLocks(enc);
             pk.SetHeldItem(set);
             // Actions that do not affect set legality
@@ -544,7 +544,7 @@ namespace PKHeX.Core.AutoMod
             pk.SetHyperTrainingFlags(set, enc); // Hypertrain
             pk.SetEncryptionConstant(enc);
             pk.SetShinyBoolean(set.Shiny, enc, regen.Extra.ShinyType);
-            pk.FixGender(enc,set);
+            pk.FixGender(enc, set);
             // Final tweaks
             pk.SetGimmicks(set);
             pk.SetGigantamaxFactor(set, enc);
@@ -814,7 +814,7 @@ namespace PKHeX.Core.AutoMod
                     enc.SetEncounterTradeIVs(pk);
                     return; // Fixed PID, no need to mutate
                 default:
-                    FindPIDIV(pk, method, hpType, set.Shiny, enc,set);
+                    FindPIDIV(pk, method, hpType, set.Shiny, enc, set);
                     ValidateGender(pk, enc.Species);
                     break;
             }
@@ -946,8 +946,8 @@ namespace PKHeX.Core.AutoMod
                         undefinedSize, undefinedSize, undefinedSize, undefinedSize, e.Ability, e.Shiny),
                     _ => throw new NotImplementedException("Unknown ITeraRaid9 type detected"),
                 };
-               applied = enc.TryApply32(pk, seed, param, criteria);
-                if(applied)
+                applied = enc.TryApply32(pk, seed, param, criteria);
+                if (applied)
                     if (IsMatchCriteria9(pk, set, criteria, compromise))
                         break;
                 if (count == 1_000)
@@ -1183,10 +1183,10 @@ namespace PKHeX.Core.AutoMod
             }
 
             var iterPKM = pk.Clone();
-            if(iterPKM.Ability != set.Ability && set.Ability != -1)
+            if (iterPKM.Ability != set.Ability && set.Ability != -1)
             {
                 var abilitypref = enc.Ability;
-                iterPKM.SetAbility(set.Ability>>1);
+                iterPKM.SetAbility(set.Ability >> 1);
             }
             var count = 0;
             var isWishmaker = Method == PIDType.BACD_R && shiny && enc is WC3 { OT_Name: "WISHMKR" };
@@ -1406,21 +1406,21 @@ namespace PKHeX.Core.AutoMod
         ///
         public static EncounterCriteria SetSpecialCriteria(EncounterCriteria criteria, IEncounterable enc, IBattleTemplate set)
         {
-            if(enc is EncounterStatic8U)
+            if (enc is EncounterStatic8U)
                 criteria = criteria with { Shiny = Shiny.Never };
-            
+
             switch (enc.Species)
             {
                 case (int)Species.Kartana when criteria.Nature == Nature.Timid && criteria.IV_ATK <= 21: // Speed boosting Timid Kartana ATK IVs <= 19
                     return criteria with { IV_HP = -1, IV_ATK = criteria.IV_ATK, IV_DEF = -1, IV_SPA = -1, IV_SPD = -1, IV_SPE = -1 };
 
                 case (int)Species.Stakataka when criteria.Nature == Nature.Lonely && criteria.IV_DEF <= 17: // Atk boosting Lonely Stakataka DEF IVs <= 15
-                    return criteria with { IV_HP = -1, IV_ATK = -1, IV_DEF = criteria.IV_DEF, IV_SPA = -1, IV_SPD = -1, IV_SPE = criteria.IV_SPE};
+                    return criteria with { IV_HP = -1, IV_ATK = -1, IV_DEF = criteria.IV_DEF, IV_SPA = -1, IV_SPD = -1, IV_SPE = criteria.IV_SPE };
 
-                case (int)Species.Pyukumuku when criteria.IV_DEF == 0 && criteria.IV_SPD == 0 && set.Ability == (int)Ability.InnardsOut : // 0 Def / 0 Spd Pyukumuku with innards out
+                case (int)Species.Pyukumuku when criteria.IV_DEF == 0 && criteria.IV_SPD == 0 && set.Ability == (int)Ability.InnardsOut: // 0 Def / 0 Spd Pyukumuku with innards out
                     return criteria with { IV_HP = -1, IV_ATK = -1, IV_DEF = criteria.IV_DEF, IV_SPA = -1, IV_SPD = criteria.IV_SPD, IV_SPE = -1 };
             }
-            
+
             return criteria with { IV_ATK = criteria.IV_ATK == 0 ? 0 : -1, IV_DEF = -1, IV_HP = -1, IV_SPA = -1, IV_SPD = -1, IV_SPE = criteria.IV_SPE == 0 ? 0 : -1 };
         }
 

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
@@ -67,8 +67,8 @@ namespace PKHeX.Core.AutoMod
         public static void SetAbility(PKM pk, IBattleTemplate set, AbilityPermission preference)
         {
             if (pk.Ability != set.Ability)
-                pk.RefreshAbility(pk is PK5 { HiddenAbility: true } ? 2 : pk.AbilityNumber >>1);
-            if(pk.Ability != set.Ability && pk.Context >= EntityContext.Gen8)
+                pk.RefreshAbility(pk is PK5 { HiddenAbility: true } ? 2 : pk.AbilityNumber >> 1);
+            if (pk.Ability != set.Ability && pk.Context >= EntityContext.Gen8 && set.Ability != -1)
                 pk.RefreshAbility(pk is PK5 { HiddenAbility: true } ? 2 : pk.PersonalInfo.GetIndexOfAbility(set.Ability));
             if (preference <= 0)
                 return;
@@ -129,7 +129,7 @@ namespace PKHeX.Core.AutoMod
             }
 
             pk.SetSuggestedFormArgument(enc.Species);
-            if (evolutionRequired || formchange || (pk.Ability != set.Ability && set.Ability!=-1))
+            if (evolutionRequired || formchange || (pk.Ability != set.Ability && set.Ability != -1))
             {
                 var abilitypref = enc.Ability;
                 SetAbility(pk, set, abilitypref);

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
@@ -165,7 +165,7 @@ namespace PKHeX.Core.AutoMod
 
                 var nick = et.GetNickname(pk.Language);
                 //Meister Magikarp's nickname is based on the save language instead of the pk language
-                if (enc is EncounterTrade8b {Species:(int)Species.Magikarp })
+                if (enc is EncounterTrade8b { Species: (int)Species.Magikarp })
                     nick = et.GetNickname(handler.Language);
                 if (nick != null)
                 {
@@ -301,7 +301,7 @@ namespace PKHeX.Core.AutoMod
         /// <param name="pk">Pokemon to modify</param>
         public static void SetEncounterTradeIVs(this IEncounterable t, PKM pk)
         {
-                pk.SetRandomIVs(minFlawless: 3);
+            pk.SetRandomIVs(minFlawless: 3);
         }
 
         /// <summary>

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
@@ -118,7 +118,7 @@ namespace PKHeX.Core.AutoMod
             ( IronLeaves, 0 ),
         };
 
-        public static readonly HashSet<int> Gen1TradeEvos = new () { (int)Kadabra, (int)Machoke, (int)Graveler, (int)Haunter };
+        public static readonly HashSet<int> Gen1TradeEvos = new() { (int)Kadabra, (int)Machoke, (int)Graveler, (int)Haunter };
 
         private static Func<int, int, int> FlagIVsAutoMod(PKM pk)
         {
@@ -341,7 +341,7 @@ namespace PKHeX.Core.AutoMod
             if (enc is WC9 wc9)
             {
                 size.WeightScalar = (byte)wc9.WeightValue;
-                size.HeightScalar= (byte)wc9.HeightValue;
+                size.HeightScalar = (byte)wc9.HeightValue;
                 return;
             }
 
@@ -424,7 +424,7 @@ namespace PKHeX.Core.AutoMod
             Span<byte> result = stackalloc byte[6];
             AwakeningUtil.SetExpectedMinimumAVs(result, (PB7)pb7);
             var EVs = set.EVs;
-            pb7.AV_HP  = Math.Max(result[0], (byte)EVs[0]);
+            pb7.AV_HP = Math.Max(result[0], (byte)EVs[0]);
             pb7.AV_ATK = Math.Max(result[1], (byte)EVs[1]);
             pb7.AV_DEF = Math.Max(result[2], (byte)EVs[2]);
             pb7.AV_SPA = Math.Max(result[3], (byte)EVs[4]);
@@ -470,7 +470,7 @@ namespace PKHeX.Core.AutoMod
                 return;
 
             IVs ??= pk.IVs;
-            t.HT_HP  = pk.IV_HP  != 31;
+            t.HT_HP = pk.IV_HP != 31;
             t.HT_ATK = pk.IV_ATK != 31 && IVs[1] > 2;
             t.HT_DEF = pk.IV_DEF != 31;
             t.HT_SPA = pk.IV_SPA != 31 && IVs[4] > 2;

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenSet.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenSet.cs
@@ -30,7 +30,7 @@ namespace PKHeX.Core.AutoMod
         public RegenSet(ICollection<string> lines, int format, Shiny shiny = Shiny.Never)
         {
             var modified = lines.Select(z => z.Replace(">=", "≥").Replace("<=", "≤"));
-            Extra = new RegenSetting {ShinyType = shiny};
+            Extra = new RegenSetting { ShinyType = shiny };
             HasExtraSettings = Extra.SetRegenSettings(modified);
             HasTrainerSettings = RegenUtil.GetTrainerInfo(modified, format, out var tr);
             Trainer = tr;

--- a/PKHeX.Core.AutoMod/AutoMod/Seeds/XOROSHIRO/Overworld8Search.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Seeds/XOROSHIRO/Overworld8Search.cs
@@ -337,12 +337,12 @@ namespace PKHeX.Core.AutoMod
             // { IV_HP, IV_ATK, IV_DEF, IV_SPE, IV_SPA, IV_SPD } (original order)
             // { IV_HP, IV_ATK, IV_DEF, IV_SPA, IV_SPD, IV_SPE } (corrected order)
             int result = 0;
-            result |= ivs[0] << (5*0);
-            result |= ivs[1] << (5*1);
-            result |= ivs[2] << (5*2);
-            result |= ivs[4] << (5*3);
-            result |= ivs[5] << (5*4);
-            result |= ivs[3] << (5*5);
+            result |= ivs[0] << (5 * 0);
+            result |= ivs[1] << (5 * 1);
+            result |= ivs[2] << (5 * 2);
+            result |= ivs[4] << (5 * 3);
+            result |= ivs[5] << (5 * 4);
+            result |= ivs[3] << (5 * 5);
             return result;
         }
     }

--- a/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
@@ -115,7 +115,7 @@ namespace PKHeX.Core.AutoMod
             int origin = pk.Generation;
             int format = pk.Format;
             if (format != origin)
-                return GetSavedTrainerData(format, (GameVersion)template_save.Game, fallback:template_save, lang:lang);
+                return GetSavedTrainerData(format, (GameVersion)template_save.Game, fallback: template_save, lang: lang);
             return GetSavedTrainerData((GameVersion)pk.Version, origin, template_save, lang);
         }
 

--- a/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Diagnostics;
 
 namespace PKHeX.Core.AutoMod
 {

--- a/PKHeX.Core.AutoMod/Enhancements/Aesthetics.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/Aesthetics.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using static PKHeX.Core.AutoMod.Aesthetics.PersonalColor;
 using static PKHeX.Core.Ball;
 using static PKHeX.Core.Species;
-using static PKHeX.Core.AutoMod.Aesthetics.PersonalColor;
 
 namespace PKHeX.Core.AutoMod
 {

--- a/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
+++ b/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PKHeX.Core.Enhancements

--- a/PKHeX.Core.Injection/BotController/Controllers/UsbBotMini.cs
+++ b/PKHeX.Core.Injection/BotController/Controllers/UsbBotMini.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using LibUsbDotNet;
-using LibUsbDotNet.Main;
 
 namespace PKHeX.Core.Injection
 {

--- a/PKHeX.Core.Injection/LiveHeXOffsets/RamOffsets.cs
+++ b/PKHeX.Core.Injection/LiveHeXOffsets/RamOffsets.cs
@@ -7,7 +7,7 @@
             return sf switch
             {
                 SAV9SV => new[] { LiveHeXVersion.SV_v101, LiveHeXVersion.SV_v110, LiveHeXVersion.SV_v120, LiveHeXVersion.SV_v130, LiveHeXVersion.SV_v131, LiveHeXVersion.SV_v132 },
-                SAV8LA => new[] { LiveHeXVersion.LA_v100 , LiveHeXVersion.LA_v101, LiveHeXVersion.LA_v102, LiveHeXVersion.LA_v111 },
+                SAV8LA => new[] { LiveHeXVersion.LA_v100, LiveHeXVersion.LA_v101, LiveHeXVersion.LA_v102, LiveHeXVersion.LA_v111 },
                 SAV8BS => new[] { LiveHeXVersion.BD_v100, LiveHeXVersion.SP_v100, LiveHeXVersion.BD_v110, LiveHeXVersion.SP_v110, LiveHeXVersion.BD_v111, LiveHeXVersion.SP_v111, LiveHeXVersion.BDSP_v112, LiveHeXVersion.BDSP_v113, LiveHeXVersion.BDSP_v120, LiveHeXVersion.BD_v130, LiveHeXVersion.SP_v130 },
                 SAV8SWSH => new[] { LiveHeXVersion.SWSH_v111, LiveHeXVersion.SWSH_v121, LiveHeXVersion.SWSH_v132 },
                 SAV7b => new[] { LiveHeXVersion.LGPE_v102 },

--- a/PKHeX.Core.Injection/Protocols/LPBDSP.cs
+++ b/PKHeX.Core.Injection/Protocols/LPBDSP.cs
@@ -9,7 +9,7 @@ namespace PKHeX.Core.Injection
     public class LPBDSP : InjectionBase
     {
         private static readonly LiveHeXVersion[] BrilliantDiamond = { LiveHeXVersion.BD_v100, LiveHeXVersion.BD_v110, LiveHeXVersion.BD_v111, LiveHeXVersion.BDSP_v112, LiveHeXVersion.BDSP_v113, LiveHeXVersion.BDSP_v120, LiveHeXVersion.BD_v130 };
-        private static readonly LiveHeXVersion[] ShiningPearl     = { LiveHeXVersion.SP_v100, LiveHeXVersion.SP_v110, LiveHeXVersion.SP_v111, LiveHeXVersion.BDSP_v112, LiveHeXVersion.BDSP_v113, LiveHeXVersion.BDSP_v120, LiveHeXVersion.SP_v130 };
+        private static readonly LiveHeXVersion[] ShiningPearl = { LiveHeXVersion.SP_v100, LiveHeXVersion.SP_v110, LiveHeXVersion.SP_v111, LiveHeXVersion.BDSP_v112, LiveHeXVersion.BDSP_v113, LiveHeXVersion.BDSP_v120, LiveHeXVersion.SP_v130 };
         private static readonly LiveHeXVersion[] SupportedVersions = ArrayUtil.ConcatAll(BrilliantDiamond, ShiningPearl);
         public static LiveHeXVersion[] GetVersions() => SupportedVersions;
 
@@ -25,7 +25,7 @@ namespace PKHeX.Core.Injection
         private const int MYSTATUS_BLOCK_SIZE = 0x50;
         private const int MYSTATUS_BLOCK_SIZE_RAM = 0x34;
 
-        public static readonly Dictionary<string, (Func<PokeSysBotMini, byte[]?>, Action<PokeSysBotMini, byte[]>)> FunctionMap = new ()
+        public static readonly Dictionary<string, (Func<PokeSysBotMini, byte[]?>, Action<PokeSysBotMini, byte[]>)> FunctionMap = new()
         {
             { "Items",          (GetItemBlock, SetItemBlock) },
             { "MyStatus",       (GetMyStatusBlock, SetMyStatusBlock) },
@@ -207,7 +207,8 @@ namespace PKHeX.Core.Injection
                 throw new Exception("Invalid Pointer string.");
 
             var item_blk = psb.com.ReadBytes(addr, ITEM_BLOCK_SIZE_RAM);
-            var items = Core.ArrayUtil.EnumerateSplit(item_blk, 0xC).Select(z => {
+            var items = Core.ArrayUtil.EnumerateSplit(item_blk, 0xC).Select(z =>
+            {
                 var retval = new byte[0x10];
                 z.Slice(0, 0x5).CopyTo(retval.AsSpan());
                 z.Slice(0x5, 0x1).CopyTo(retval, 0x8);
@@ -229,7 +230,8 @@ namespace PKHeX.Core.Injection
                 throw new Exception("Invalid Pointer string.");
 
             data = data.Slice(0, ITEM_BLOCK_SIZE);
-            var items = Core.ArrayUtil.EnumerateSplit(data, 0x10).Select(z => {
+            var items = Core.ArrayUtil.EnumerateSplit(data, 0x10).Select(z =>
+            {
                 var retval = new byte[0xC];
                 z.Slice(0, 0x5).CopyTo(retval.AsSpan());
                 z.Slice(0x8, 0x1).CopyTo(retval, 0x5);

--- a/PKHeX.Core.Injection/Protocols/LPLGPE.cs
+++ b/PKHeX.Core.Injection/Protocols/LPLGPE.cs
@@ -41,7 +41,7 @@ namespace PKHeX.Core.Injection
             var slotofs = psb.GetSlotOffset(box, slot);
             var StoredLength = psb.SlotSize - 0x1C;
             psb.com.WriteBytes(data.Slice(0, StoredLength), slotofs);
-            psb.com.WriteBytes(data.AsSpan(StoredLength).ToArray(), slotofs + (ulong) StoredLength + 0x70);
+            psb.com.WriteBytes(data.AsSpan(StoredLength).ToArray(), slotofs + (ulong)StoredLength + 0x70);
         }
 
         public override void SendBox(PokeSysBotMini psb, byte[] boxData, int box)


### PR DESCRIPTION
Fixes the Wish Salamence set. It doesn't have an ability so the second check was breaking it after it was already corrected.
All tests currently pass (other than the occasional failures from difficult sets such as shiny Colo Eevee).

Standardizes white space and I manually changed all line endings for the different files to LF.