### PR TITLE
IsIncompatibleGB -> IsCompatibleGB

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -115,7 +115,7 @@ namespace PKHeX.Core.AutoMod
                 raw = raw.SanityCheckLocation(enc);
                 if (raw.IsEgg) // PGF events are sometimes eggs. Force hatch them before proceeding
                     raw.HandleEggEncounters(enc, tr);
-
+                
                 raw.PreSetPIDIV(enc, set, criteria);
 
                 // Transfer any VC1 via VC2, as there may be GSC exclusive moves requested.
@@ -127,7 +127,7 @@ namespace PKHeX.Core.AutoMod
                 if (pk == null)
                     continue;
 
-                if (EntityConverter.IsIncompatibleGB(pk, template.Japanese, pk.Japanese))
+                if (!EntityConverter.IsCompatibleGB(pk, template.Japanese, pk.Japanese))
                     continue;
 
                 pk = pk.Clone(); // Handle Nickname-Trash issues (weedle word filter)


### PR DESCRIPTION
As per PKHeX commit https://github.com/kwsch/PKHeX/commit/ca2bd3baf49c505912882aa5429712da27e60c62#diff-ea1bd98ed7d1326a80dd148d98163fd2e284d31a30c39f7adc541e4a641f2f33, the API EntityConverter.IsIncompatibleGB changed to IsCompatibleGB, and switched its return types.