### PR TITLE
fix: add support for Blazor WebAssembly

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1837,7 +1837,12 @@ namespace PKHeX.Core.AutoMod
         /// <summary>
         /// Wrapper function for GetLegalFromTemplate but with a Timeout
         /// </summary>
-        public static AsyncLegalizationResult GetLegalFromTemplateTimeout(this ITrainerInfo dest, PKM template, IBattleTemplate set, bool nativeOnly = false)
+        public static AsyncLegalizationResult GetLegalFromTemplateTimeout(this ITrainerInfo dest, PKM template, IBattleTemplate set, bool nativeOnly = false) =>
+            GetLegalFromTemplateTimeoutAsync(dest, template, set, nativeOnly)
+                .GetAwaiter()
+                .GetResult();
+        
+        public static async Task<AsyncLegalizationResult> GetLegalFromTemplateTimeoutAsync(this ITrainerInfo dest, PKM template, IBattleTemplate set, bool nativeOnly = false)
         {
             AsyncLegalizationResult GetLegal()
             {
@@ -1855,9 +1860,15 @@ namespace PKHeX.Core.AutoMod
                 }
             }
 
-            var task = Task.Run(GetLegal);
-            var first = task.TimeoutAfter(new TimeSpan(0, 0, 0, Timeout))?.Result;
-            return first ?? new AsyncLegalizationResult(template, LegalizationResult.Timeout);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(Timeout));
+            try
+            {
+                return await Task.Run(GetLegal, cts.Token);
+            }
+            catch (TaskCanceledException e)
+            {
+                return new AsyncLegalizationResult(template, LegalizationResult.Timeout);
+            }
         }
 
         /// <summary>
@@ -1867,17 +1878,6 @@ namespace PKHeX.Core.AutoMod
         {
             public readonly PKM Created = pk;
             public readonly LegalizationResult Status = res;
-        }
-
-        private static async Task<AsyncLegalizationResult?>? TimeoutAfter(this Task<AsyncLegalizationResult> task, TimeSpan timeout)
-        {
-            using var cts = new CancellationTokenSource(timeout);
-            var delay = Task.Delay(timeout, cts.Token);
-            var completedTask = await Task.WhenAny(task, delay).ConfigureAwait(false);
-            if (completedTask != task)
-                return null;
-
-            return await task.ConfigureAwait(false); // will re-fire exception if present
         }
 
         private static GameVersion[] GetPairedVersions(GameVersion version, IEnumerable<GameVersion> versionlist)

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1839,6 +1839,7 @@ namespace PKHeX.Core.AutoMod
         /// </summary>
         public static AsyncLegalizationResult GetLegalFromTemplateTimeout(this ITrainerInfo dest, PKM template, IBattleTemplate set, bool nativeOnly = false) =>
             GetLegalFromTemplateTimeoutAsync(dest, template, set, nativeOnly)
+                .ConfigureAwait(false)
                 .GetAwaiter()
                 .GetResult();
         
@@ -1863,7 +1864,8 @@ namespace PKHeX.Core.AutoMod
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(Timeout));
             try
             {
-                return await Task.Run(GetLegal, cts.Token);
+                return await Task.Run(GetLegal, cts.Token)
+                    .ConfigureAwait(false);
             }
             catch (TaskCanceledException e)
             {

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/Legalizer.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/Legalizer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using static PKHeX.Core.AutoMod.APILegality;
 
 namespace PKHeX.Core.AutoMod
@@ -34,7 +35,29 @@ namespace PKHeX.Core.AutoMod
         {
             var set = new RegenTemplate(pk, tr.Generation);
             var almres = tr.GetLegalFromTemplateTimeout(pk, set);
-            return almres.Status == LegalizationResult.VersionMismatch ? throw new MissingMethodException("PKHeX and Plugins have a version mismatch") : almres.Created;
+            var result = almres.Status;
+            
+            return result == LegalizationResult.VersionMismatch 
+                ? throw new MissingMethodException("PKHeX and Plugins have a version mismatch") 
+                : almres.Created;
+        }
+        
+        /// <summary>
+        /// Tries to regenerate the <see cref="pk"/> into a valid pkm.
+        /// </summary>
+        /// <param name="tr">Source/Destination trainer</param>
+        /// <param name="pk">Currently invalid pkm data</param>
+        /// <param name="withTimeout">Will timeout after the configured at <see cref="APILegality.Timeout"/> </param>
+        /// <returns>Legalized PKM (hopefully legal)</returns>
+        public static async Task<PKM> LegalizeAsync(this ITrainerInfo tr, PKM pk)
+        {
+            var set = new RegenTemplate(pk, tr.Generation);
+            var almres = await tr.GetLegalFromTemplateTimeoutAsync(pk, set);
+            var result = almres.Status;
+            
+            return result == LegalizationResult.VersionMismatch 
+                ? throw new MissingMethodException("PKHeX and Plugins have a version mismatch") 
+                : almres.Created;
         }
 
         /// <summary>

--- a/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
@@ -9,8 +9,9 @@ namespace PKHeX.Core.AutoMod
     /// </summary>
     public static class TrainerSettings
     {
+        private static readonly string ProcessPath = Environment.ProcessPath ?? string.Empty;
         private static readonly TrainerDatabase Database = new();
-        public static readonly string TrainerPath = Path.Combine(Path.GetDirectoryName(Environment.ProcessPath)!, "trainers");
+        public static readonly string TrainerPath = Path.Combine(Path.GetDirectoryName(ProcessPath) ?? string.Empty , "trainers");
         private static readonly SimpleTrainerInfo DefaultFallback8 = new(GameVersion.SW) { Generation = 8 };
         private static readonly SimpleTrainerInfo DefaultFallback7 = new(GameVersion.UM) { Generation = 7 };
         private static readonly GameVersion[] FringeVersions =


### PR DESCRIPTION
## Context

I'm currently working on a CLI and a webassembly version of PKHeX based on PKHeX.Core, and I'm now adding support to auto-legality mode ([proof-of-concept here](https://github.com/arleypadua/PKHeX.CLI/pull/46)), but unfortunately Blazor WebAssembly does not play good with calling `.Result` on tasks because it does not really support thread blocking calls

Furthermore it also has no concept of `ProcessPath`, throwing an exception whenever I access any static member of `TrainerSettings`

This MR is mostly refactoring a few things (functionality does not change) so that it works in any runtime/environment.