### PR TITLE
Gen4 unown criteria & Seed generation

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1309,8 +1309,6 @@ public static class APILegality
     /// <param name="set"></param>
     private static void FindPIDIV(PKM pk, PIDType method, int hiddenPower, bool shiny, IEncounterTemplate enc, IBattleTemplate set)
     {
-        if (enc.Generation == 4 && pk.Species == (ushort)Species.Unown) // set unown form for gen 4 encounters because otherwise you get a random form from database
-            pk.Form = set.Form;  //this setting of the form could probably be replaced with adding Form to EncounterCriteria so that it comes out of the database correctly.
         if (method == PIDType.None)
         {
             method = FindLikelyPIDType(enc);
@@ -1583,7 +1581,7 @@ public static class APILegality
                 Revise(criteria, def: criteria.IV_DEF, spe: criteria.IV_SPE),
             (int)Species.Pyukumuku when criteria is { IV_DEF: 0, IV_SPD: 0 } && set.Ability == (int)Ability.InnardsOut =>
                 Revise(criteria, def: criteria.IV_DEF, spd: criteria.IV_SPD),
-            (int)Species.Unown when enc.Generation is 4 => criteria,
+            (int)Species.Unown when enc.Generation is 4 => criteria with { Form = (sbyte)set.Form},
 
             _ => Revise(criteria, atk: criteria.IV_ATK == 0 ? (sbyte)0 : (sbyte)-1, spe: criteria.IV_SPE == 0 ? (sbyte)0 : (sbyte)-1),
         };

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -86,7 +86,8 @@ public static class APILegality
         var criteria = EncounterCriteria.GetCriteria(set, template.PersonalInfo, mutations);
         if (regen.EncounterFilters.Any())
             encounters = encounters.Where(enc => BatchEditing.IsFilterMatch(regen.EncounterFilters, enc));
-
+        if (regen.SeedFilters.Any())
+            encounters = encounters.Where(enc => enc is (IGenerateSeed32 or IGenerateSeed64)); // Only allow seed generation for seed encounters
         // For sets that require a specific level, force the level maximum that the generator will yield.
         // Most encounters generate with minimum level; only those with checked PID/IV will have non-minimum levels.
 
@@ -119,8 +120,31 @@ public static class APILegality
             raw = raw.SanityCheckLocation(enc);
             if (raw.IsEgg) // PGF events are sometimes eggs. Force hatch them before proceeding
                 raw.HandleEggEncounters(enc, tr);
-            raw.PreSetPIDIV(enc, set, criteria);
-
+            if (enc is (IGenerateSeed32 or IGenerateSeed64) && regen.SeedFilters.Any())
+            {
+                switch (enc)
+                {
+                    case IGenerateSeed32 GS32:
+                        var converted = Convert.ToUInt32(regen.SeedFilters[0], 16);
+                        GS32.GenerateSeed32(raw, converted);
+                        if (enc is ITeraRaid9 tr9)
+                        {
+                            var type = Tera9RNG.GetTeraType(converted, tr9.TeraType, enc.Species, enc.Form);
+                            ((PK9)raw).TeraTypeOriginal = (MoveType)type;
+                            if (set.TeraType != MoveType.Any && (MoveType)type != set.TeraType && TeraTypeUtil.CanChangeTeraType(enc.Species))
+                                ((PK9)raw).SetTeraType(set.TeraType);
+                        }
+                        break;
+                    case IGenerateSeed64 GS64:
+                        var converted64 = Convert.ToUInt64(regen.SeedFilters[0], 16);
+                        GS64.GenerateSeed64(raw, converted64); break;
+                };
+                
+            }
+            else
+            {
+                raw.PreSetPIDIV(enc, set, criteria);
+            }
             // Transfer any VC1 via VC2, as there may be GSC exclusive moves requested.
             if (dest.Generation >= 7 && raw is PK1 basepk1)
                 raw = basepk1.ConvertToPK2();
@@ -138,7 +162,7 @@ public static class APILegality
 
             // Apply final details
             ApplySetDetails(pk, set, dest, enc, regen, criteria);
-
+            
             // Apply final tweaks to the data.
             if (pk is IGigantamax gmax && gmax.CanGigantamax != set.CanGigantamax)
             {

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenSet.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenSet.cs
@@ -15,6 +15,7 @@ public sealed class RegenSet
     public StringInstructionSet Batch { get; }
     public IReadOnlyList<StringInstruction> EncounterFilters { get; }
     public IReadOnlyList<StringInstruction> VersionFilters { get; }
+    public IReadOnlyList<string> SeedFilters { get; }
 
     public readonly bool HasExtraSettings;
     public readonly bool HasTrainerSettings;
@@ -62,12 +63,14 @@ public sealed class RegenSet
             Batch = new StringInstructionSet(Array.Empty<string>());
             EncounterFilters = [];
             VersionFilters = [];
+            SeedFilters = [];
             return;
         }
 
         List<StringInstruction> eFilter = [];
         List<StringInstruction> vFilter = [];
         List<StringInstruction> mods = [];
+        List<string> sFilter = [];
         for (int i = 0; i < lines.Count;)
         {
             var line = lines[i];
@@ -91,6 +94,12 @@ public sealed class RegenSet
                 lines.RemoveAt(i);
                 continue;
             }
+            if (RegenUtil.IsSeedFilter(sanitized,out var s))
+            {
+                sFilter.Add(s);
+                lines.RemoveAt(i);
+                continue;
+            }
             if (line == string.Empty)
             {
                 lines.RemoveAt(i);
@@ -101,6 +110,7 @@ public sealed class RegenSet
         Batch = new([], mods);
         EncounterFilters = eFilter;
         VersionFilters = vFilter;
+        SeedFilters = sFilter;
     }
 
     public string GetSummary()
@@ -118,8 +128,11 @@ public sealed class RegenSet
         if (EncounterFilters.Any())
             sb.AppendLine(RegenUtil.GetSummary(EncounterFilters));
 
-        if (VersionFilters.Count > 0)
+        if (VersionFilters.Any())
             sb.AppendLine(RegenUtil.GetSummary(VersionFilters));
+
+        if(SeedFilters.Any())
+            sb.AppendLine(SeedFilters[0]);
 
         return sb.ToString();
     }

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
@@ -87,7 +87,17 @@ public static class RegenUtil
         var replaced = line[1..];
         return StringInstruction.TryParseFilter(replaced, out result);
     }
-
+    public static bool IsSeedFilter(ReadOnlySpan<char> line, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+        if (!line.StartsWith(EncounterFilterPrefix))
+            return false;
+        if (!line[2..].StartsWith("Seed="))
+            return false;
+        var replaced = line[7..];
+        result = "0x"+replaced.ToString();
+        return replaced != string.Empty;
+    }
     public static bool TrySplit(ReadOnlySpan<char> line, out (string Key, string Value) result)
     {
         result = default;

--- a/PKHeX.Core.AutoMod/Enhancements/BattleTemplateLegality.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/BattleTemplateLegality.cs
@@ -158,7 +158,7 @@ public static class BattleTemplateLegality
 
     private static int Recurse(IBattleTemplate set, Memory<ushort> request, PKM blank, GameVersion[] gamelist, List<ushort> moves)
     {
-        if (moves.Count == 1)
+        if (moves.Count <= 1)
             return 0;
 
         // Breadth first search to find the most valid moveset -- remove one move and check, and restore if not.


### PR DESCRIPTION
Utilizes Form in PKHeX Encounter Criteria to generate the requested Unown form for gen 4 instead of doing it internally
Utilizes PKHeX new GenerateSeed32 and GenerateSeed64 to be able to generate pokemon with a given seed. This is useful for difficult to solve sets or when the user knows their origin seed and wants to generate from that.

To utilize this feature include
~.Seed= in your showdown set
example:
Snover
~.Seed=88A54678f3409003