### PR TITLE
Battle template

### DIFF
--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -255,7 +255,7 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
             var data = Remote.Bot.ReadSlot(0, 0);
             var pkm = SAV.SAV.GetDecryptedPKM(data.ToArray());
             bool valid = pkm.Species <= pkm.MaxSpeciesID && pkm.ChecksumValid &&
-                         pkm is { Species: 0, EncryptionConstant: 0 } or { Species: not 0, Language: not (int)LanguageID.Hacked and not (int)LanguageID.UNUSED_6 };
+                         pkm is { Species: 0, EncryptionConstant: 0 } or { Species: not 0, Language: not (int)LanguageID.None and not (int)LanguageID.UNUSED_6 };
             if (valid)
                 return (LiveHeXValidation.None, "", version);
         }
@@ -315,7 +315,7 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
         PKM? pkm = SAV.SAV.GetDecryptedPKM(data.ToArray());
         bool valid = pkm is not null && pkm.Species <= pkm.MaxSpeciesID && pkm.ChecksumValid &&
                      pkm is { Species: 0, EncryptionConstant: 0 }
-                         or { Species: not 0, Language: not (int)LanguageID.Hacked and not (int)LanguageID.UNUSED_6 };
+                         or { Species: not 0, Language: not (int)LanguageID.None and not (int)LanguageID.UNUSED_6 };
         return !_settings.EnableDevMode && !valid && InjectionBase.CheckRAMShift(Remote.Bot, out string err) ? (LiveHeXValidation.RAMShift, err, lv) : !valid ? (LiveHeXValidation.GameVersion,"Invalid data found.",LiveHeXVersion.Unknown): (LiveHeXValidation.None, "", lv);
     }
 

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -238,6 +238,7 @@ public static class ShowdownSetLoader
         APILegality.AllowTrainerOverride = settings.AllowTrainerOverride;
         APILegality.Timeout = settings.Timeout;
         APILegality.ForceLevel100for50 = settings.ForceLevel100for50;
+        APILegality.ExportFormat = settings.ExportFormat;
         //APILegality.AllowHOMETransferGeneration = settings.AllowHOMETransferGeneration;
         APILegality.RandTypes = settings.RandomTypes;
         Legalizer.EnableEasterEggs = settings.EnableEasterEggs;

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -86,6 +86,10 @@ public class PluginSettings
     [Description("Force Showdown sets with level 50 to level 100")]
     public bool ForceLevel100for50 { get; set; } = true;
 
+    [Category(Customization)]
+    [Description("Export format for ALM Showdown Template")]
+    public BattleTemplateDisplayStyle ExportFormat { get; set; } = BattleTemplateDisplayStyle.Showdown;
+
     // Legality
     [Category(Legality)]
     [Description("Global timeout per Pokémon being generated (in seconds)")]

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -30,11 +30,11 @@ public static class APILegality
     public static bool AllowTrainerOverride { get; set; }
     public static bool AllowBatchCommands { get; set; } = true;
     public static bool ForceLevel100for50 { get; set; } = true;
-    public static bool AllowHOMETransferGeneration { get; set; } = true;
+    public static BattleTemplateDisplayStyle ExportFormat { get; set; } = BattleTemplateDisplayStyle.Showdown;
     public static MoveType[] RandTypes { get; set; } = [];
     public static int Timeout { get; set; } = 15;
 
-    private static bool AllowHOME => ParseSettings.Settings.HOMETransfer.HOMETransferTrackerNotPresent != Severity.Invalid;
+    public static bool AllowHOME => ParseSettings.Settings.HOMETransfer.HOMETransferTrackerNotPresent != Severity.Invalid;
 
     /// <summary>
     /// Main function that auto legalizes based on the legality

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
@@ -151,7 +151,7 @@ public static class ShowdownEdits
             pk.EXP = Experience.GetEXP((byte)(enc.LevelMin + 1), PersonalTable.HGSS[enc.Species].EXPGrowth) - 1;
 
         var finallang = lang ?? currentlang;
-        if (finallang == LanguageID.Hacked)
+        if (finallang == LanguageID.None)
             finallang = LanguageID.English;
 
         pk.Language = (int)finallang;

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
@@ -367,7 +367,7 @@ public static class SimpleEdits
     public static void SetHTLanguage(this PKM pk, byte prefer)
     {
         var preferID = (LanguageID)prefer;
-        if (preferID is LanguageID.Hacked or LanguageID.UNUSED_6)
+        if (preferID is LanguageID.None or LanguageID.UNUSED_6)
             prefer = 2; // prefer english
 
         if (pk is IHandlerLanguage h)

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplate.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplate.cs
@@ -56,7 +56,7 @@ public sealed class RegenTemplate : IBattleTemplate
         DynamaxLevel = set.DynamaxLevel;
         TeraType = set.TeraType;
 
-        ParentLines = set.Text;
+        ParentLines = set.GetText(APILegality.ExportFormat == BattleTemplateDisplayStyle.Legacy ? BattleTemplateExportSettings.CommunityStandard : BattleTemplateExportSettings.Showdown);
         SanitizeMoves(set, Moves);
     }
 

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
@@ -103,7 +103,10 @@ public static class RegenUtil
         var index = line.IndexOf(Splitter);
         if (index < 0)
             return false;
-
+        line = line[(index+2)..]; // remove "Unknown Token: " from invalid lines to process
+        index = line.IndexOf(Splitter);
+        if (index < 0)
+            return false;
         var key = line[..index];
         var value = line[(index + 1)..].Trim();
         result = (key.ToString(), value.ToString());

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenUtil.cs
@@ -161,7 +161,7 @@ public static class RegenUtil
     /// <param name="ver"></param>
     public static ITrainerInfo MutateLanguage(this ITrainerInfo tr, LanguageID? lang, GameVersion ver)
     {
-        if (lang is LanguageID.UNUSED_6 or LanguageID.Hacked or null)
+        if (lang is LanguageID.UNUSED_6 or LanguageID.None or null)
             return tr;
 
         if (tr is PokeTrainerDetails p)

--- a/PKHeX.Core.AutoMod/Enhancements/Aesthetics.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/Aesthetics.cs
@@ -1073,7 +1073,7 @@ public static class Aesthetics
             return null;
         }
 
-        return lang is LanguageID.Hacked or LanguageID.UNUSED_6 ? LanguageID.English : lang;
+        return lang is LanguageID.None or LanguageID.UNUSED_6 ? LanguageID.English : lang;
     }
 
     private static bool IsDisallowed(this RibbonIndex ribbon) => ribbon switch

--- a/PKHeX.Core.AutoMod/Enhancements/BattleTemplateLegality.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/BattleTemplateLegality.cs
@@ -105,7 +105,7 @@ public static class BattleTemplateLegality
             return string.Format(HIDDEN_ABILITY_UNAVAILABLE, species_name);
 
         // Home Checks
-        if (!APILegality.AllowHOMETransferGeneration)
+        if (!APILegality.AllowHOME)
         {
             if (encounters.All(z => HomeTrackerUtil.IsRequired(z, failed)))
                 return string.Format(HOME_TRANSFER_ONLY, species_name);

--- a/PKHeX.Core.Enhancements/Teams/ShowdownTeamSet.cs
+++ b/PKHeX.Core.Enhancements/Teams/ShowdownTeamSet.cs
@@ -15,17 +15,17 @@ public record ShowdownTeamSet(string TeamName, IReadOnlyList<ShowdownSet> Team, 
 
     public string Summary => $"{Format}: {TeamName}";
 
-    public string Export(string language = GameLanguage.DefaultLanguage)
+    public string Export(BattleTemplateExportSettings settings)
     {
         var sb = new StringBuilder();
-        return Export(sb, language);
+        return Export(sb, settings);
     }
 
-    public string Export(StringBuilder sb, string language = GameLanguage.DefaultLanguage)
+    public string Export(StringBuilder sb, BattleTemplateExportSettings settings)
     {
         sb.AppendLine(GetHeading(Format, TeamName));
         foreach (var set in Team)
-            sb.AppendLine(set.LocalizedText(language));
+            sb.AppendLine(set.GetText(settings));
         return sb.ToString();
     }
 


### PR DESCRIPTION
Replaced `LanguageID.Hacked` with `LanguageID.None` across
multiple classes (`LiveHeXUI`, `ShowdownEdits`, `SimpleEdits`,
`RegenUtil`, `Aesthetics`) to treat `LanguageID.None` as the
default/invalid language. Ensured `LanguageID.None` defaults
to `LanguageID.English` where applicable for consistency.

Refactored `ShowdownTeamSet.Export` to accept a
`BattleTemplateExportSettings` object instead of a string,
enabling more flexible export configurations.
Adjust logic to sanitize invalid lines by removing the
"Unknown Token: " prefix and recalculating the Splitter
index. Return false if the Splitter is not found after
sanitization, ensuring proper validation before extracting key-value pairs.
- Added `ExportFormat` property to `APILegality` and `PluginSettings`
  to support customizable ALM Showdown template exports.
- Updated `ShowdownSetLoader` and `RegenTemplate` to use the new
  `ExportFormat` property for consistent export behavior.
- Replaced `AllowHOMETransferGeneration` with `AllowHOME` in
  `APILegality` for streamlined HOME legality checks.
- Updated `BattleTemplateLegality` to align with the new `AllowHOME`
  property.
- Removed outdated code and performed general cleanup to ensure
  alignment with the new settings.