### PR TITLE
Only store LiveHeX port if using USB-botbase

### DIFF
--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -42,7 +42,18 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
         this.TranslateInterface(WinFormsTranslator.CurrentLanguage);
 
         TB_IP.Text = _settings.LatestIP;
-        var default_port = RamOffsets.IsSwitchTitle(sav.SAV) ? 6000 : 8000; // default port for loaded save
+
+        // Default Wi-Fi ports for loaded save, 6000 for Switch, 8000 for 3DS
+        var default_port = RamOffsets.IsSwitchTitle(sav.SAV) ? 6000 : 8000;
+
+        if (_settings.USBBotBasePreferred)
+        {
+            // Only use the saved port if using USB-Botbase
+            if (int.TryParse(_settings.LatestPort, out int port))
+                default_port = port;
+            // Allow editing of the port field.
+            TB_Port.ReadOnly = false;
+        }
         TB_Port.Text = default_port.ToString();
         SetInjectionTypeView();
 
@@ -355,6 +366,9 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
 
         x.Slots.Publisher.Subscribers.Remove(this);
         _settings.LatestIP = TB_IP.Text;
+        // Only save the port if using USB-Botbase
+        if (_settings.USBBotBasePreferred)
+            _settings.LatestPort = TB_Port.Text;
         _settings.Save();
     }
 

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -48,6 +48,10 @@ public class PluginSettings
     public string LatestIP { get; set; } = "192.168.1.65";
 
     [Category(Connection)]
+    [Description("Stores the last port used by LiveHeX.")]
+    public string LatestPort { get; set; } = "6000";
+
+    [Category(Connection)]
     [Description("Allows LiveHeX to use USB-Botbase instead of sys-botbase.")]
     public bool USBBotBasePreferred { get; set; } = false;
 


### PR DESCRIPTION
I would like to eventually restructure the LiveHeX UI so it's not as tall, but this should be a temporary fix for when we forgot that usb-botbase needs configurable ports in https://github.com/santacrab2/PKHeX-Plugins/commit/8d49515ac4124eade24d353305fa4e36bd045410.

This is how everything works now:
- The "Port" field remains uneditable for Wi-Fi connections, but is editable if usb-botbase is preferred.
- The "Port" field will automatically populate `6000` or `8000` for Wi-Fi connections depending on the loaded save.
- If usb-botbase is preferred in settings, it will read the last port from saved settings instead of using 6000 or 8000.
- If usb-botbase is preferred in settings, it will update the last port in saved settings when the program is closed. Otherwise it will keep the original value. This prevents swapping to Wi-Fi and storing 6000 or 8000, which don't need to be stored at all.

In the future, I'd like the Wi-Fi vs USB config to be on the UI rather than in the program settings.
