### PR TITLE
Priority order

### DIFF
--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -233,7 +233,18 @@ public static class ShowdownSetLoader
         APILegality.UseMarkings = settings.UseMarkings;
         APILegality.EnableDevMode = settings.EnableDevMode;
         APILegality.PrioritizeGame = settings.PrioritizeGame;
-        APILegality.PrioritizeGameVersion = settings.PriorityGameVersion;
+        // If the version is in GameUtil.GetVersionsWithinRange then continue, if its not, then remove it. If the list is missing any from GameUtil.GetVersionsWithinRange, add them
+        // Synchronize PriorityOrder with GameUtil.GetVersionsWithinRange
+        var validVersions = GameUtil.GetVersionsWithinRange(SaveFileEditor.SAV,SaveFileEditor.SAV.Generation).ToList();
+        // Remove any versions from PriorityOrder that are not in validVersions
+        settings.PriorityOrder.RemoveAll(ver => !validVersions.Contains(ver));
+        // Add any versions from validVersions that are missing in PriorityOrder
+        foreach (var ver in validVersions)
+        {
+            if (!settings.PriorityOrder.Contains(ver))
+                settings.PriorityOrder.Add(ver);
+        }
+        APILegality.PriorityOrder = settings.PriorityOrder;
         APILegality.SetBattleVersion = settings.SetBattleVersion;
         APILegality.AllowTrainerOverride = settings.AllowTrainerOverride;
         APILegality.Timeout = settings.Timeout;

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -233,7 +233,7 @@ public static class ShowdownSetLoader
         APILegality.UseMarkings = settings.UseMarkings;
         APILegality.EnableDevMode = settings.EnableDevMode;
         APILegality.PrioritizeGame = settings.PrioritizeGame;
-        GameVersion[] validVersions = [.. Enum.GetValues<GameVersion>().Where(ver => ver <= (GameVersion)51)];
+        GameVersion[] validVersions = [.. Enum.GetValues<GameVersion>().Where(ver => ver <= (GameVersion)51 && ver > GameVersion.Any)];
         foreach (var ver in validVersions)
         {
             if (!settings.PriorityOrder.Contains(ver))

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -233,12 +233,7 @@ public static class ShowdownSetLoader
         APILegality.UseMarkings = settings.UseMarkings;
         APILegality.EnableDevMode = settings.EnableDevMode;
         APILegality.PrioritizeGame = settings.PrioritizeGame;
-        // If the version is in GameUtil.GetVersionsWithinRange then continue, if its not, then remove it. If the list is missing any from GameUtil.GetVersionsWithinRange, add them
-        // Synchronize PriorityOrder with GameUtil.GetVersionsWithinRange
-        var validVersions = GameUtil.GetVersionsWithinRange(SaveFileEditor.SAV,SaveFileEditor.SAV.Generation).ToList();
-        // Remove any versions from PriorityOrder that are not in validVersions
-        settings.PriorityOrder.RemoveAll(ver => !validVersions.Contains(ver));
-        // Add any versions from validVersions that are missing in PriorityOrder
+        GameVersion[] validVersions = [.. Enum.GetValues<GameVersion>().Where(ver => ver <= (GameVersion)51)];
         foreach (var ver in validVersions)
         {
             if (!settings.PriorityOrder.Contains(ver))

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -67,12 +67,12 @@ public class PluginSettings
 
     [Category(Customization)]
     [Description(
-        "If enabled, tries to generate a Pokémon based on PriorityOrder first."
+        "If enabled, tries to generate a Pokémon based on PriorityOrder."
     )]
     public bool PrioritizeGame { get; set; } = false;
 
     [Category(Customization)]
-    [Description("Setting this to \"Any\" prioritizes the current save game, and setting a specific game prioritizes that instead.")]
+    [Description("The order of GameVersions ALM will attempt to legalize from.")]
     public List<GameVersion> PriorityOrder { get; set; } =
         [..Enum.GetValues<GameVersion>().Where(ver => ver > GameVersion.Any && ver <= (GameVersion)51)];
 

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -73,7 +73,8 @@ public class PluginSettings
 
     [Category(Customization)]
     [Description("Setting this to \"Any\" prioritizes the current save game, and setting a specific game prioritizes that instead.")]
-    public List<GameVersion> PriorityOrder { get; set; } = [..Enum.GetValues<GameVersion>().Where(ver => ver <=(GameVersion)51)];
+    public List<GameVersion> PriorityOrder { get; set; } =
+        [..Enum.GetValues<GameVersion>().Where(ver => ver > GameVersion.Any && ver <= (GameVersion)51)];
 
     [Category(Customization)]
     [Description("Adds all ribbons that are legal according to PKHeX legality.")]

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -66,13 +66,13 @@ public class PluginSettings
 
     [Category(Customization)]
     [Description(
-        "If enabled, tries to generate a Pokémon based on PrioritizeGameVersion first."
+        "If enabled, tries to generate a Pokémon based on PriorityOrder first."
     )]
     public bool PrioritizeGame { get; set; } = false;
 
     [Category(Customization)]
     [Description("Setting this to \"Any\" prioritizes the current save game, and setting a specific game prioritizes that instead.")]
-    public GameVersion PriorityGameVersion { get; set; } = GameVersion.Any;
+    public List<GameVersion> PriorityOrder { get; set; } = [];
 
     [Category(Customization)]
     [Description("Adds all ribbons that are legal according to PKHeX legality.")]

--- a/AutoLegalityMod/PluginSettings.cs
+++ b/AutoLegalityMod/PluginSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using PKHeX.Core;
 
@@ -72,7 +73,7 @@ public class PluginSettings
 
     [Category(Customization)]
     [Description("Setting this to \"Any\" prioritizes the current save game, and setting a specific game prioritizes that instead.")]
-    public List<GameVersion> PriorityOrder { get; set; } = [];
+    public List<GameVersion> PriorityOrder { get; set; } = [..Enum.GetValues<GameVersion>().Where(ver => ver <=(GameVersion)51)];
 
     [Category(Customization)]
     [Description("Adds all ribbons that are legal according to PKHeX legality.")]

--- a/AutoModTests/TestUtil.cs
+++ b/AutoModTests/TestUtil.cs
@@ -25,6 +25,7 @@ public static class TestUtil
             Legalizer.EnableEasterEggs = false;
             APILegality.SetAllLegalRibbons = false;
             APILegality.Timeout = 99999;
+            APILegality.PrioritizeGame = false;
             ParseSettings.Settings.Handler.CheckActiveHandler = false;
             ParseSettings.Settings.HOMETransfer.HOMETransferTrackerNotPresent = Severity.Fishy;
             ParseSettings.Settings.Nickname.SetAllTo(new NicknameRestriction { NicknamedTrade = Severity.Fishy, NicknamedMysteryGift = Severity.Fishy});

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -25,7 +25,7 @@ public static class APILegality
     public static bool EnableDevMode { get; set; }
     public static string LatestAllowedVersion { get; set; } = "0.0.0.0";
     public static bool PrioritizeGame { get; set; } = true;
-    public static GameVersion PrioritizeGameVersion { get; set; }
+    public static List<GameVersion> PriorityOrder { get; set; } = [];
     public static bool SetBattleVersion { get; set; }
     public static bool AllowTrainerOverride { get; set; }
     public static bool AllowBatchCommands { get; set; } = true;
@@ -304,7 +304,7 @@ public static class APILegality
         var versionlist = GameUtil.GetVersionsWithinRange(template, template.Generation);
         var gamelist = !nativeOnly ? [.. versionlist.OrderByDescending(c => c.GetGeneration())] : GetPairedVersions(destVer, versionlist);
         if (PrioritizeGame)
-            gamelist = PrioritizeGameVersion == GameVersion.Any ? PrioritizeVersion(gamelist, destVer.GetIsland()) : PrioritizeVersion(gamelist, PrioritizeGameVersion);
+            gamelist = [..PriorityOrder];
 
         if (template.AbilityNumber == 4 && destVer.GetGeneration() < 8)
             gamelist = [.. gamelist.Where(z => z.GetGeneration() is not 3 and not 4)];

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -304,7 +304,7 @@ public static class APILegality
         var versionlist = GameUtil.GetVersionsWithinRange(template, template.Generation);
         var gamelist = !nativeOnly ? [.. versionlist.OrderByDescending(c => c.GetGeneration())] : GetPairedVersions(destVer, versionlist);
         if (PrioritizeGame)
-            gamelist = [..PriorityOrder];
+            gamelist = [..PriorityOrder.Where(z=>versionlist.Contains(z))];
 
         if (template.AbilityNumber == 4 && destVer.GetGeneration() < 8)
             gamelist = [.. gamelist.Where(z => z.GetGeneration() is not 3 and not 4)];


### PR DESCRIPTION
Priority Version -> Priority Order
Priority Version was born out of the desire to be able to ensure that the Original Trainer Version was favored over other Versions. This still led to issues with the outcome of the met version and also only allowed the user to Target 1 preferred game version but still returning to descending order following. 

This update will allow the user to control the order of the versions ALM attempts to legalize from as its base encounter outright. This will be controlled through the new **PriorityOrder** setting that replaces PriorityVersion. PrioritizeGame still toggles this setting. If PrioritizeGame is set to True ALM will utilize the custom order in PriorityOrder setting, if it is False ALM will use the classic descending generational order 9->1.