### PR TITLE
Add tests for GenerateEgg and fix egg generation for gen 5+

### DIFF
--- a/AutoModTests/EggTests.cs
+++ b/AutoModTests/EggTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using PKHeX.Core;
+using PKHeX.Core.AutoMod;
+using System.Text;
+using Xunit;
+using static PKHeX.Core.GameVersion;
+
+namespace AutoModTests;
+
+/// <summary>
+/// Class to test multiple pastebins of eggs to ensure they are parsed and regenerated correctly for each generation.
+/// </summary>
+public static class EggTests
+{
+    static EggTests() => TestUtil.InitializePKHeXEnvironment();
+
+    private static string TestPath => TestUtil.GetTestFolder("ShowdownSets");
+    private static string LogDirectory => Path.Combine(Directory.GetCurrentDirectory(), "logs");
+
+    private static List<TestResult> RunVerification(string file, ReadOnlySpan<GameVersion> saves)
+    {
+        var results = new List<TestResult>(saves.Length);
+        foreach (var s in saves)
+        {
+            var result = new TestResult(s);
+            results.Add(result);
+            var sav = BlankSaveFile.Get(s.GetContext(), "ALMUT");
+            RecentTrainerCache.SetRecentTrainer(sav);
+
+            var lines = File.ReadAllLines(file).Where(z => !z.StartsWith("====="));
+            var sets = ShowdownParsing.GetShowdownSets(lines).ToList();
+
+            for (int i = 0; i < sets.Count; i++)
+            {
+                var set = sets[i];
+                if (set.Species == 0)
+                    continue;
+
+                try
+                {
+                    Debug.Write($"Checking Set {i:000} [Species: {(Species)set.Species}] from File {file} using Save {s}: ");
+                    var created = sav.GenerateEgg(set, out var almres);
+                    var la = new LegalityAnalysis(created);
+                    if (almres is LegalizationResult.Regenerated && la.Valid)
+                    {
+                        Debug.WriteLine("Valid");
+                        result.Legal.Add(set);
+                    }
+                    else
+                    {
+                        result.Failed.Add(new(set, la));
+                        Debug.WriteLine($"Invalid Set for {(Species)set.Species} in file {file} with set: {set.Text}");
+                    }
+                }
+                catch
+                {
+                    Debug.WriteLine($"Exception for {(Species)set.Species} in file {file} with set: {set.Text}");
+                }
+            }
+        }
+        return results;
+    }
+
+    [Theory]
+    [InlineData(EggPK2, new[] { GSC })]
+    [InlineData(EggPK3, new[] { R, S, E, FR, LG })]
+    [InlineData(EggPK4, new[] { D, P, Pt, HG, SS })]
+    [InlineData(EggPK5, new[] { B, W, B2, W2 })]
+    [InlineData(EggPK6, new[] { X, Y, OR, AS })]
+    [InlineData(EggPK7, new[] { SN, MN, US, UM })]
+    [InlineData(EggPK8, new[] { SW, SH })]
+    [InlineData(EggPB8, new[] { BD, SP })]
+    [InlineData(EggPK9, new[] { SL, VL })]
+    public static void VerifyFile(string path, GameVersion[] testversions)
+    {
+        Directory.CreateDirectory(LogDirectory);
+        var full = Path.Combine(TestPath, path);
+        var dev = APILegality.EnableDevMode;
+        APILegality.EnableDevMode = true;
+
+        var res = RunVerification(full, testversions);
+        APILegality.EnableDevMode = dev;
+
+        var msg = new StringBuilder();
+        var error = new StringBuilder();
+        var testfailed = false;
+        foreach (var result in res)
+        {
+            var illegalcount = result.Failed.Count;
+            if (illegalcount == 0)
+                continue;
+
+            testfailed = true;
+            msg.AppendLine($"GameVersion {result.Version} : Illegal: {illegalcount} | Legal: {result.Legal.Count}");
+
+            error.AppendLine($"=============== GameVersion: {result.Version} ===============");
+            foreach (var f in result.Failed)
+            {
+                error.AppendLine(f.Set.Text);
+                error.AppendLine(f.Result.Report());
+                error.AppendLine();
+            }
+        }
+        if (error.Length != 0)
+        {
+            var fileName = $"{Path.GetFileName(path).Replace('.', '_')}{DateTime.Now:_yyyy-MM-dd-HH-mm-ss}.log";
+            var dest = Path.Combine(LogDirectory, fileName);
+            File.WriteAllText(dest, error.ToString());
+        }
+
+        testfailed.Should().BeFalse(msg.ToString());
+    }
+
+    // Egg test file paths
+    private const string EggPK2 = "Egg Tests/pk2.txt";
+    private const string EggPK3 = "Egg Tests/pk3.txt";
+    private const string EggPK4 = "Egg Tests/pk4.txt";
+    private const string EggPK5 = "Egg Tests/pk5.txt";
+    private const string EggPK6 = "Egg Tests/pk6.txt";
+    private const string EggPK7 = "Egg Tests/pk7.txt";
+    private const string EggPK8 = "Egg Tests/pk8.txt";
+    private const string EggPB8 = "Egg Tests/pb8.txt";
+    private const string EggPK9 = "Egg Tests/pk9.txt";
+
+    public record TestResult(GameVersion Version)
+    {
+        public readonly List<FailedTest> Failed = [];
+        public readonly List<ShowdownSet> Legal = [];
+    }
+
+    public record FailedTest(ShowdownSet Set, LegalityAnalysis Result);
+}

--- a/AutoModTests/ShowdownSets/Egg Tests/pb8.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pb8.txt
@@ -1,0 +1,41 @@
+Egg (Turtwig) (M)
+Ability: Shell Armor
+Modest Nature
+IVs: 25 HP / 21 Atk / 16 Def / 2 SpA / 5 SpD / 27 Spe
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=BD
+- Tackle
+
+Egg (Chimchar) (M)
+Ability: Iron Fist
+Relaxed Nature
+IVs: 22 HP / 14 Atk / 23 Def / 9 SpA / 12 SpD / 16 Spe
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=SP
+- Scratch
+- Leer
+
+Egg (Piplup) (F)
+Ability: Torrent
+Level: 1
+Friendship: 1
+Docile Nature
+IVs: 29 HP / 9 Atk / 24 Def / 1 SpA / 2 SpD / 15 Spe
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=BDSP
+- Pound

--- a/AutoModTests/ShowdownSets/Egg Tests/pk2.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk2.txt
@@ -1,0 +1,59 @@
+EGG (Bulbasaur) (M)
+Level: 5
+Shiny: Yes
+OT: Manu
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Tackle
+- Growl
+
+EGG (Charmander) (M)
+Level: 5
+IVs: 5 HP / 14 Atk / 3 Def / 9 SpA / 9 SpD / 2 Spe
+OT: Manu
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Scratch
+- Growl
+
+EGG (Squirtle) (F)
+Level: 5
+OT: Manu
+Shiny: Yes
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Tackle
+- Tail Whip
+
+EGG (Chikorita) (F)
+Level: 5
+IVs: 10 HP / 12 Def / 0 SpA / 0 SpD / 3 Spe
+OT: Manu
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Tackle
+- Growl
+
+EGG (Cyndaquil) (M)
+Level: 5
+OT: Manu
+Shiny: Yes
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Tackle
+- Leer
+
+EGG (Totodile) (F)
+Level: 5
+IVs: 14 HP / 3 Def / 6 SpA / 6 SpD / 9 Spe
+OT: Manu
+OTGender: Male
+TID: 12345
+~=Version=GSC
+- Scratch
+- Leer

--- a/AutoModTests/ShowdownSets/Egg Tests/pk3.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk3.txt
@@ -1,0 +1,84 @@
+タマゴ (Treecko) (M)
+Ability: Overgrow
+Sassy Nature
+IVs: 21 Atk / 9 SpA / 1 Spe
+Ball: Poke Ball
+Shiny: Star
+OT: Ｍａｎｕ
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=S
+- Pound
+- Leer
+
+タマゴ (Torchic) (F)
+Ability: Blaze
+Level: 5
+Rash Nature
+IVs: 1 HP / 16 Atk / 20 SpA
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=R
+- Scratch
+- Growl
+
+タマゴ (Mudkip) (M)
+Ability: Torrent
+Level: 5
+Relaxed Nature
+IVs: 27 HP / 18 Atk
+Ball: Poke Ball
+OT: Ｍａｎｕ
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=E
+- Tackle
+- Growl
+
+タマゴ (Bulbasaur) (F)
+Ability: Overgrow
+Level: 5
+Timid Nature
+IVs: 1 HP / 22 Atk / 9 SpD
+Ball: Poke Ball
+Shiny: Yes
+OT: Ｍａｎｕ
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=FR
+- Tackle
+- Growl
+
+タマゴ (Charmander) (M)
+Ability: Blaze
+Rash Nature
+IVs: 4 Atk / 23 Def / 21 SpA
+Ball: Poke Ball
+Shiny: No
+OT: Ｍａｎｕ
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=LG
+- Scratch
+- Growl
+
+タマゴ (Squirtle) (F)
+Ability: Torrent
+Level: 5
+IVs: 2 Atk / 28 SpA
+Ball: Poke Ball
+OT: Ｍａｎｕ
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=FRLG
+- Tackle
+- Tail Whip

--- a/AutoModTests/ShowdownSets/Egg Tests/pk4.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk4.txt
@@ -1,0 +1,82 @@
+Egg (Turtwig) (M)
+Ability: Overgrow
+Docile Nature
+IVs: 20 Atk / 30 SpD / 20 Spe
+Ball: Poke Ball
+Shiny: Yes
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=D
+- Tackle
+
+Egg (Chimchar) (F)
+Ability: Blaze
+Relaxed Nature
+IVs: 5 Atk / 13 Def / 23 Spe
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=P
+- Scratch
+- Leer
+
+Egg (Piplup) (M)
+Ability: Torrent
+Timid Nature
+IVs: 26 HP / 24 Def / 21 SpA
+Ball: Poke Ball
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=Pt
+- Pound
+
+Egg (Chikorita) (M)
+Ability: Overgrow
+Bold Nature
+IVs: 14 SpA / 7 SpD / 19 Spe
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=HG
+- Tackle
+- Growl
+
+Egg (Cyndaquil) (M)
+Ability: Blaze
+Level: 1
+Friendship: 0
+Calm Nature
+IVs: 19 Atk / 21 SpA / 18 SpD
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=SS
+- Tackle
+- Leer
+
+Egg (Totodile) (M)
+Ability: Torrent
+Rash Nature
+IVs: 28 Atk / 13 SpD
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=HGSS
+- Scratch
+- Leer

--- a/AutoModTests/ShowdownSets/Egg Tests/pk5.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk5.txt
@@ -1,0 +1,53 @@
+Egg (Snivy) (M)
+Ability: Overgrow
+Timid Nature
+IVs: 21 Atk / 5 SpA / 2 SpD
+Ball: Poke Ball
+OT: Manu
+OTGender: Female
+TID: 44510
+SID: 61374
+~=Version=W
+- Tackle
+
+Egg (Tepig) (M)
+Ability: Blaze
+Level: 1
+Bashful Nature
+IVs: 27 HP / 11 Def / 23 SpA
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Female
+TID: 44510
+SID: 61374
+~=Version=B
+- Tackle
+
+Egg (Oshawott) (M)
+Ability: Torrent
+Level: 1
+Naughty Nature
+IVs: 8 HP / 17 SpA / 16 Spe
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Female
+TID: 44510
+SID: 61374
+~=Version=W2
+- Tackle
+
+Egg (Patrat) (F)
+Ability: Analytic
+Level: 1
+Quiet Nature
+IVs: 0 HP / 27 Def / 2 Spe
+Ball: Poke Ball
+Shiny: Yes
+OT: Manu
+OTGender: Female
+TID: 44510
+SID: 61374
+~=Version=B2
+- Tackle

--- a/AutoModTests/ShowdownSets/Egg Tests/pk6.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk6.txt
@@ -1,0 +1,81 @@
+Egg (Chespin) (F)
+Ability: Bulletproof
+Bashful Nature
+IVs: 29 HP / 24 Def / 18 Spe
+Ball: Poke Ball
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=X
+- Tackle
+- Growl
+
+Egg (Fennekin) (M)
+Ability: Magician
+Lonely Nature
+IVs: 26 Def / 20 SpA / 6 Spe
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=Y
+- Scratch
+- Tail Whip
+
+Egg (Froakie) (F)
+Ability: Protean
+Lonely Nature
+IVs: 30 HP / 25 SpA / 14 SpD
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=OR
+- Pound
+- Growl
+
+Egg (Treecko) (F)
+Ability: Unburden
+Mild Nature
+IVs: 25 Atk / 6 Def / 21 Spe
+Ball: Poke Ball
+Shiny: Yes
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=AS
+- Pound
+- Leer
+
+Egg (Torchic) (M)
+Ability: Speed Boost
+Bold Nature
+IVs: 20 HP / 10 Atk / 2 Spe
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=ORAS
+- Scratch
+- Growl
+
+Egg (Mudkip) (M)
+Ability: Damp
+Calm Nature
+IVs: 6 HP / 6 Atk / 27 SpA
+Ball: Poke Ball
+OT: Manu
+OTGender: Male
+TID: 44510
+SID: 61374
+~=Version=XY
+- Tackle
+- Growl

--- a/AutoModTests/ShowdownSets/Egg Tests/pk7.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk7.txt
@@ -1,0 +1,54 @@
+Egg (Rowlet) (F)
+Ability: Long Reach
+Naughty Nature
+IVs: 7 HP / 0 Def / 10 SpD
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=SN
+- Tackle
+- Leafage
+
+Egg (Litten) (F)
+Ability: Blaze
+Relaxed Nature
+IVs: 18 Atk / 5 Def / 24 SpD
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=MN
+- Scratch
+- Ember
+
+Egg (Popplio) (F)
+Ability: Liquid Voice
+Hardy Nature
+IVs: 4 HP / 2 Def / 26 SpD
+Ball: Poke Ball
+Shiny: Yes
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=US
+- Pound
+- Water Gun
+
+Egg (Pikipek) (M)
+Ability: Skill Link
+Bold Nature
+IVs: 13 Def
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=UM
+- Peck

--- a/AutoModTests/ShowdownSets/Egg Tests/pk8.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk8.txt
@@ -1,0 +1,42 @@
+Egg (Grookey) (M)
+Ability: Grassy Surge
+Lax Nature
+IVs: 6 Atk / 21 SpA / 3 SpD
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Male
+TID: 250974
+SID: 4022
+~=Version=SW
+- Scratch
+- Growl
+
+Egg (Scorbunny) (M)
+Ability: Libero
+Docile Nature
+IVs: 3 Atk / 19 SpA / 19 Spe
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Male
+TID: 250974
+SID: 4022
+~=Version=SH
+- Tackle
+- Growl
+
+Egg (Sobble) (F)
+Ability: Torrent
+Dynamax Level: 0
+Brave Nature
+IVs: 27 Atk / 7 Def / 3 SpA
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Male
+TID: 250974
+SID: 4022
+~=Version=SWSH
+- Pound
+- Growl

--- a/AutoModTests/ShowdownSets/Egg Tests/pk9.txt
+++ b/AutoModTests/ShowdownSets/Egg Tests/pk9.txt
@@ -1,0 +1,49 @@
+Egg (Sprigatito) (M)
+Ability: Protean
+Tera Type: Grass
+Jolly Nature
+IVs: 11 Atk / 1 SpA / 25 Spe
+Ball: Poke Ball
+Shiny: No
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=SL
+- Scratch
+- Tail Whip
+- Leafage
+
+Egg (Fuecoco) (F)
+Ability: Unaware
+Tera Type: Fire
+Timid Nature
+IVs: 6 Atk / 27 SpD / 21 Spe
+Ball: Poke Ball
+Shiny: Star
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=VL
+- Tackle
+- Leer
+- Ember
+
+Egg (Quaxly) (M)
+Ability: Moxie
+Level: 1
+Friendship: 1
+Tera Type: Water
+Gentle Nature
+IVs: 22 Atk / 25 Def / 24 SpA
+Ball: Poke Ball
+Shiny: Square
+OT: Manu
+OTGender: Female
+TID: 250974
+SID: 4022
+~=Version=SV
+- Pound
+- Growl
+- Water Gun

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1397,7 +1397,7 @@ public static class APILegality
     public static PKM GenerateEgg(this ITrainerInfo dest, ShowdownSet set, out LegalizationResult result)
     {
         result = LegalizationResult.Failed;
-        var template = EntityBlank.GetBlank(dest.Generation);
+        var template = EntityBlank.GetBlank(dest);
         template.ApplySetDetails(set);
         var destVer = dest.Version;
         if (destVer <= 0 && dest is SaveFile s)

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1430,7 +1430,7 @@ public static class APILegality
                 var loc = isTraded
                     ? Locations.TradedEggLocation(sav.Generation, sav.Version)
                     : LocationEdits.GetNoneLocation(raw);
-                raw.MetLocation = (ushort)loc;
+                raw.MetLocation = loc;
             }
             else if (raw is PK3)
             {

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -1441,6 +1441,10 @@ public static class APILegality
             raw.IsNicknamed = EggStateLegality.IsNicknameFlagSet(raw);
             raw.Nickname = SpeciesName.GetEggName(raw.Language, raw.Format);
 
+            // Wipe met date
+            if (raw.Format >= 5)
+                raw.MetDate = null;
+
             // Wipe egg memories
             if (raw.Format >= 6)
                 raw.ClearMemories();


### PR DESCRIPTION
I was running into issues generating eggs from my SysBot fork, so I put together a series of tests to help identify the problem. I also added a couple of sets for older generations to confirm that everything was working as expected.

The test logic is based on `TeamTests.cs` since the nature of the tests is very similar. I chose not to modify the original `TeamTests`, as the differences between `GetLegalFromSet` and `GenerateEgg` (regen usage, return values, and how showdown text is interpreted; e.g., distinguishing between an egg generation request and "Egg" as a Pokémon nickname) would have required changes that might complicate the existing test suite. Feel free to merge, edit, or remove these new tests if you find them redundant.

I included tests covering different species, shinyness, moves, and game versions. They can be easily expanded later with more detailed cases (e.g., unique egg moves, Apriballs, etc.).

**Fixes identified thanks to the tests:**

* New PKHeX versions now flag as illegal any Gen 5+ unhatched egg with a non-null `MetDate`
* BDSP egg templates were incorrectly initialized as `PK8` instead of `PB8`, causing the generator to fail when a BDSP egg move was specified in the showdown set
