### PR TITLE
Pokémon Ranch encounters have random IVs without correlations

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -807,7 +807,6 @@ public static class APILegality
             // EncounterTrade4 doesn't have fixed PIDs, so don't early return
             case EncounterTrade3:
             case EncounterTrade4PID:
-            case EncounterTrade4RanchGift:
                 pk.SetEncounterTradeIVs();
                 return; // Fixed PID, no need to mutate
         }


### PR DESCRIPTION
If you open these encounters in PKHeX, you can change its IVs around without any legality issues.