### PR TITLE
Invert Icons for Dark Mode

### DIFF
--- a/AutoLegalityMod/GUI/WinFormsUtil.cs
+++ b/AutoLegalityMod/GUI/WinFormsUtil.cs
@@ -94,4 +94,24 @@ public static class WinFormsUtil
 
     public static IEnumerable<T> FormsOfType<T>()
         where T : Form => Application.OpenForms.OfType<T>();
+
+    internal static Bitmap GetIconForTheme(Bitmap bmp, bool invert)
+    {
+        if (!invert) return bmp;
+        var dark = new Bitmap(bmp);
+
+        var (h, w) = (dark.Height, dark.Width);
+
+        for (var y = 0; y < h; y++)
+        {
+            for (var x = 0; x < w; x++)
+            {
+                var color = dark.GetPixel(x, y);
+                var inv = Color.FromArgb(color.A, 0xFF - color.R, 0xFF - color.G, 0xFF - color.B);
+                dark.SetPixel(x, y, inv);
+            }
+        }
+
+        return dark;
+    }
 }

--- a/AutoLegalityMod/Plugins/AutoModPlugin.cs
+++ b/AutoLegalityMod/Plugins/AutoModPlugin.cs
@@ -156,7 +156,11 @@ public abstract class AutoModPlugin : IPlugin
         return modmenu;
     }
 
-    private static ToolStripMenuItem CreateBaseGroupItem() => new(ParentMenuText) { Image = Resources.menuautolegality, Name = ParentMenuName };
+    private static ToolStripMenuItem CreateBaseGroupItem() => new(ParentMenuText)
+    {
+        Image = WinFormsUtil.GetIconForTheme(Resources.menuautolegality, Application.IsDarkModeEnabled), 
+        Name = ParentMenuName
+    };
 
     protected abstract void AddPluginControl(ToolStripDropDownItem modmenu);
 

--- a/AutoLegalityMod/Plugins/ExportBoxToShowdown.cs
+++ b/AutoLegalityMod/Plugins/ExportBoxToShowdown.cs
@@ -14,11 +14,11 @@ public class ExportBoxToShowdown : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.exportboxtoshowdown };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.exportboxtoshowdown, Application.IsDarkModeEnabled) };
         ctrl.Click += (_, _) => Export(SaveFileEditor);
         ctrl.Name = "Menu_ExportBoxtoShowdown";
         modmenu.DropDownItems.Add(ctrl);
-        var ctrl2 = new ToolStripMenuItem(Name2) { Image = Resources.exportboxtoshowdown };
+        var ctrl2 = new ToolStripMenuItem(Name2) { Image = WinFormsUtil.GetIconForTheme(Resources.exportboxtoshowdown, Application.IsDarkModeEnabled) };
         ctrl2.Click += (_, _) => Export2();
         ctrl2.Name = "Menu_ExportActivetoShowdown";
         modmenu.DropDownItems.Add(ctrl2);

--- a/AutoLegalityMod/Plugins/LegalizeBoxes.cs
+++ b/AutoLegalityMod/Plugins/LegalizeBoxes.cs
@@ -14,7 +14,7 @@ public class LegalizeBoxes : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.legalizeboxes };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.legalizeboxes, Application.IsDarkModeEnabled) };
         ctrl.Click += Legalize;
         ctrl.Name = "Menu_LeaglizeBoxes";
         modmenu.DropDownItems.Add(ctrl);

--- a/AutoLegalityMod/Plugins/LiveHex.cs
+++ b/AutoLegalityMod/Plugins/LiveHex.cs
@@ -12,7 +12,7 @@ public class LiveHeX : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var c1 = new ToolStripMenuItem(Name) { Image = Resources.wifi };
+        var c1 = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.wifi, Application.IsDarkModeEnabled) };
         c1.Click += (_, _) =>
         {
             var sav = SaveFileEditor.SAV;

--- a/AutoLegalityMod/Plugins/LivingDex.cs
+++ b/AutoLegalityMod/Plugins/LivingDex.cs
@@ -20,7 +20,7 @@ public class LivingDex : AutoModPlugin
     {
         var ctrl = new ToolStripMenuItem(Name)
         {
-            Image = Resources.livingdex,
+            Image = WinFormsUtil.GetIconForTheme(Resources.livingdex, Application.IsDarkModeEnabled),
             ShortcutKeys = Keys.Alt | Keys.E,
         };
         ctrl.Click += GenLivingDex;

--- a/AutoLegalityMod/Plugins/MGDBDownloader.cs
+++ b/AutoLegalityMod/Plugins/MGDBDownloader.cs
@@ -15,7 +15,7 @@ public class MGDBDownloader : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.mgdbdownload };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.mgdbdownload, Application.IsDarkModeEnabled) };
         ctrl.Click += DownloadMGDB;
         ctrl.Name = "Menu_MGDBDownloader";
         modmenu.DropDownItems.Add(ctrl);

--- a/AutoLegalityMod/Plugins/PKSMBankPlugin.cs
+++ b/AutoLegalityMod/Plugins/PKSMBankPlugin.cs
@@ -16,13 +16,13 @@ public class PKSMBankPlugin : AutoModPlugin
 
         var c1 = new ToolStripMenuItem("Merge PKM into PKSM Bank")
         {
-            Image = Resources.upload,
+            Image = WinFormsUtil.GetIconForTheme(Resources.upload, Application.IsDarkModeEnabled),
         };
         c1.Click += (_, _) => Import();
         c1.Name = "Menu_CreatePKSMBank";
         var c2 = new ToolStripMenuItem("Split PKSM Bank into PKM")
         {
-            Image = Resources.mgdbdownload,
+            Image = WinFormsUtil.GetIconForTheme(Resources.mgdbdownload, Application.IsDarkModeEnabled),
         };
         c2.Click += (_, _) => Export();
         c2.Name = "Menu_ExportPKSMBank";
@@ -31,7 +31,7 @@ public class PKSMBankPlugin : AutoModPlugin
         ctrl.DropDownItems.Add(c2);
         modmenu.DropDownItems.Add(ctrl);
 
-        ctrl.Image = Resources.flagbrew;
+        ctrl.Image = WinFormsUtil.GetIconForTheme(Resources.flagbrew, Application.IsDarkModeEnabled);
     }
 
     private static void Export()

--- a/AutoLegalityMod/Plugins/PasteImporter.cs
+++ b/AutoLegalityMod/Plugins/PasteImporter.cs
@@ -21,7 +21,7 @@ public class PasteImporter : AutoModPlugin
     {
         var ctrl = new ToolStripMenuItem(Name)
         {
-            Image = Resources.autolegalitymod,
+            Image = WinFormsUtil.GetIconForTheme(Resources.autolegalitymod, Application.IsDarkModeEnabled),
             ShortcutKeys = Keys.Control | Keys.I,
         };
         ctrl.Click += ImportPaste;

--- a/AutoLegalityMod/Plugins/SettingsEditor.cs
+++ b/AutoLegalityMod/Plugins/SettingsEditor.cs
@@ -12,7 +12,7 @@ public class SettingsEditor : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.settings };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.settings, Application.IsDarkModeEnabled) };
         ctrl.Click += SettingsForm;
         ctrl.Name = "Menu_ALMSettingsEditor";
         modmenu.DropDownItems.Add(ctrl);

--- a/AutoLegalityMod/Plugins/SmogonGenner.cs
+++ b/AutoLegalityMod/Plugins/SmogonGenner.cs
@@ -17,7 +17,7 @@ public class SmogonGenner : AutoModPlugin
         var ctrl = new ToolStripMenuItem(Name)
         {
             Name = "Menu_SmogonGenner",
-            Image = Resources.smogongenner,
+            Image = WinFormsUtil.GetIconForTheme(Resources.smogongenner, Application.IsDarkModeEnabled),
         };
         modmenu.DropDownItems.Add(ctrl);
         ctrl.Click += SmogonGenning;

--- a/AutoLegalityMod/Plugins/TrainerTemplates.cs
+++ b/AutoLegalityMod/Plugins/TrainerTemplates.cs
@@ -16,7 +16,7 @@ public class TrainerTemplates : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.settings };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.settings, Application.IsDarkModeEnabled) };
         ctrl.Click += CreateTrainerTemplates;
         ctrl.Name = "Menu_TrainerTemplates";
         modmenu.DropDownItems.Add(ctrl);

--- a/AutoLegalityMod/Plugins/TransferLivingDex.cs
+++ b/AutoLegalityMod/Plugins/TransferLivingDex.cs
@@ -15,7 +15,7 @@ public class TransferLivingDex : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.livingdex };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.livingdex, Application.IsDarkModeEnabled) };
         ctrl.Click += GenTLivingDex;
         ctrl.Name = "Menu_TransferDex";
         modmenu.DropDownItems.Add(ctrl);

--- a/AutoLegalityMod/Plugins/URLGenning.cs
+++ b/AutoLegalityMod/Plugins/URLGenning.cs
@@ -12,7 +12,7 @@ public class URLGenning : AutoModPlugin
 
     protected override void AddPluginControl(ToolStripDropDownItem modmenu)
     {
-        var ctrl = new ToolStripMenuItem(Name) { Image = Resources.urlimport };
+        var ctrl = new ToolStripMenuItem(Name) { Image = WinFormsUtil.GetIconForTheme(Resources.urlimport, Application.IsDarkModeEnabled) };
         ctrl.Click += URLGen;
         ctrl.Name = "Menu_URLGenning";
         modmenu.DropDownItems.Add(ctrl);


### PR DESCRIPTION
This PR inverts the ToolStripMenuItem Icons when dark mode is active.

<img width="715" height="331" alt="image" src="https://github.com/user-attachments/assets/8f2b55fb-f8b7-43db-a869-1890bfc4665d" />

This approach was chosen over PKHeX's ``InvertToolStripIcons`` method due to the Smogon Set icon containing both black and white pixels, so changing all to white would be insufficient. As the icons are so small, the overhead from iterating through every pixel is negligible.