### PR TITLE
FR LG Livehex

### DIFF
--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -1,14 +1,15 @@
+using AutoModPlugins.GUI;
+using PKHeX.Core;
+using PKHeX.Core.Injection;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using AutoModPlugins.GUI;
-using PKHeX.Core;
-using PKHeX.Core.Injection;
-using System.Drawing;
 namespace AutoModPlugins;
 
 public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
@@ -301,6 +302,8 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
 
         var compatible = InjectionBase.SaveCompatibleWithTitle(SAV.SAV, titleID);
         var lv = compatible ? InjectionBase.GetVersionFromTitle(titleID, gameVer) : LiveHeXVersion.Unknown;
+        if (lv >= LiveHeXVersion.FRLG_E_v100)
+            gameName = "FireRed/LeafGreen";
         if (!compatible && !_settings.EnableDevMode)
         {
             var saveName = GameInfo.GetVersionName(SAV_Version);
@@ -327,7 +330,6 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
         Remote.Bot = new PokeSysBotMini(connect_ver, nx);
         if (lv is LiveHeXVersion.Unknown && _settings.EnableDevMode)
             return (LiveHeXValidation.None, "", lv);
-
         var data = Remote.Bot.ReadSlot(0, 0);
         var pkm = SAV.SAV.GetDecryptedPKM(data.ToArray());
         bool valid = pkm.Species <= pkm.MaxSpeciesID && pkm.ChecksumValid &&
@@ -540,6 +542,12 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
             var blks = save_blocks.Order();
             return blks;
         }
+        if (Remote.Bot.Injector is LPFRLG)
+        {
+            var save_blocks = LPFRLG.SCBlocks[lv].Select(z => z.Display).Distinct();
+            var blks = save_blocks.Order();
+            return blks;
+        }
 
         return new List<string>();
     }
@@ -733,7 +741,8 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
     {
         var txt = CB_BlockName.Text;
         var version = Remote.Bot.Version;
-
+        if (Remote.Bot.Version >= LiveHeXVersion.FRLG_E_v100)
+            ReadBlock(Remote.Bot, SAV.SAV, "SecurityKey", out _);
         var valid = ReadBlock(Remote.Bot, SAV.SAV, txt, out var data);
         if (!valid || data is null)
         {
@@ -817,7 +826,16 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
             var res = form.ShowDialog();
             write = res == DialogResult.OK;
         }
+        else if (sb is object)
+        {
+            using var form = new SimpleHexEditor(data[0]);
 
+            form.PG_BlockView.Visible = true;
+            form.PG_BlockView.SelectedObject = SAV.SAV;
+            
+            var res = form.ShowDialog();
+            write = res == DialogResult.OK;
+        }
         if (!write)
             return;
 
@@ -888,12 +906,18 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
             {
                 LPBasic => [.. LPBasic.SCBlocks[version].Where(z => z.Display == display)],
                 LPPointer => [.. LPPointer.SCBlocks[version].Where(z => z.Display == display)],
+                LPFRLG => [.. LPFRLG.SCBlocks[version].Where(z => z.Display == display)],
                 _ => [],
             };
 
             if (subblocks.Length == 0)
                 return false;
-
+            if (Remote.Bot.Injector is LPFRLG)
+            {
+                var prop = sav.GetType().GetProperty(display) ?? throw new Exception($"{display} not found");
+                sb = prop.GetValue(sav);
+                return sb is not null;
+            }
             // Check for SCBlocks or SaveBlocks based on name. (SCBlocks will invoke the hex editor, SaveBlocks will invoke a property grid
             var props = sav.GetType().GetProperty("Blocks");
             if (props is null)
@@ -1042,3 +1066,5 @@ internal class HexTextBox : TextBox
         base.WndProc(ref m);
     }
 }
+
+

--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -741,8 +741,12 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
     {
         var txt = CB_BlockName.Text;
         var version = Remote.Bot.Version;
-        if (Remote.Bot.Version >= LiveHeXVersion.FRLG_E_v100)
+        if (version >= LiveHeXVersion.FRLG_E_v100)
+        {
+            if (txt == "Items")
+                txt = "Large";
             ReadBlock(Remote.Bot, SAV.SAV, "SecurityKey", out _);
+        }
         var valid = ReadBlock(Remote.Bot, SAV.SAV, txt, out var data);
         if (!valid || data is null)
         {
@@ -915,7 +919,10 @@ public partial class LiveHeXUI : Form, ISlotViewer<PictureBox>
             if (Remote.Bot.Injector is LPFRLG)
             {
                 var prop = sav.GetType().GetProperty(display) ?? throw new Exception($"{display} not found");
-                sb = prop.GetValue(sav);
+                if (display == "Large")
+                    sb = ((SAV3)sav).Large.ToArray();
+                else
+                    sb = prop.GetValue(sav);
                 return sb is not null;
             }
             // Check for SCBlocks or SaveBlocks based on name. (SCBlocks will invoke the hex editor, SaveBlocks will invoke a property grid

--- a/AutoLegalityMod/GUI/SimpleHexEditor.Designer.cs
+++ b/AutoLegalityMod/GUI/SimpleHexEditor.Designer.cs
@@ -125,6 +125,7 @@ namespace AutoModPlugins.GUI
             RT_Timer.Size = new System.Drawing.Size(61, 23);
             RT_Timer.TabIndex = 20;
             RT_Timer.Value = new decimal(new int[] { 1000, 0, 0, 0 });
+            RT_Timer.ValueChanged += RT_Timer_ValueChanged;
             // 
             // B_Load
             // 

--- a/AutoLegalityMod/GUI/SimpleHexEditor.cs
+++ b/AutoLegalityMod/GUI/SimpleHexEditor.cs
@@ -12,7 +12,7 @@ namespace AutoModPlugins.GUI;
 public partial class SimpleHexEditor : Form
 {
     public byte[] Bytes;
-    private readonly System.Timers.Timer refresh = new();
+    public readonly System.Timers.Timer refresh = new();
     private static ulong address;
     private static bool decrypt;
     private static uint block_key;
@@ -85,7 +85,7 @@ public partial class SimpleHexEditor : Form
             }
 
             var r_text = string.Join(" ", result.Select(z => $"{z:X2}"));
-            RTB_RAM.Invoke((MethodInvoker) delegate
+            RTB_RAM.Invoke((MethodInvoker)delegate
             {
                 if (RTB_RAM.Text != r_text) // Prevent text updates if there is no update since they hinder copying
                 {
@@ -95,7 +95,7 @@ public partial class SimpleHexEditor : Form
             if (RT_Timer.Enabled)
             {
                 RT_Timer.Invoke(
-                    (MethodInvoker) delegate
+                    (MethodInvoker)delegate
                     {
                         refresh.Interval = (double)RT_Timer.Value;
                     });
@@ -214,6 +214,11 @@ public partial class SimpleHexEditor : Form
             }
             catch (Exception) { Debug.Write("form closing error"); }
         }
+    }
+
+    private void RT_Timer_ValueChanged(object sender, EventArgs e)
+    {
+        refresh.Interval = (double)RT_Timer.Value;
     }
 }
 

--- a/PKHeX.Core.Injection/BlockData.cs
+++ b/PKHeX.Core.Injection/BlockData.cs
@@ -9,5 +9,5 @@ public record BlockData
     public ulong Offset { get; set; }
     public RWMethod Method { get; set; } = RWMethod.Heap;
     public SCTypeCode Type { get; set; } = SCTypeCode.None;
-    public bool IsSecured { get; set; }
+    public bool IsSecured { get; set; } = false;
 }

--- a/PKHeX.Core.Injection/BlockData.cs
+++ b/PKHeX.Core.Injection/BlockData.cs
@@ -9,4 +9,5 @@ public record BlockData
     public ulong Offset { get; set; }
     public RWMethod Method { get; set; } = RWMethod.Heap;
     public SCTypeCode Type { get; set; } = SCTypeCode.None;
+    public bool IsSecured { get; set; }
 }

--- a/PKHeX.Core.Injection/Enums/LiveHeXVersion.cs
+++ b/PKHeX.Core.Injection/Enums/LiveHeXVersion.cs
@@ -51,4 +51,11 @@ public enum LiveHeXVersion
     ZA_v103 = 37,
     ZA_v200 = 38,
     ZA_v201 = 39,
+
+    FRLG_E_v100 = 40,
+    FRLG_S_v100 = 41,
+    FRLG_F_v100 = 42,
+    FRLG_D_v100 = 43,
+    FRLG_I_v100 = 44,
+    FRLG_J_v100 = 45,
 }

--- a/PKHeX.Core.Injection/InjectionBase/InjectionBase.cs
+++ b/PKHeX.Core.Injection/InjectionBase/InjectionBase.cs
@@ -27,7 +27,18 @@ public abstract class InjectionBase
     private const string Violet_ID = "01008F6008C5E000";
 
     private const string ZA_ID = "0100F43008C44000";
-
+    private const string FR_E_ID = "0100554023408000";
+    private const string LG_E_ID = "010034D02340E000";
+    private const string FR_S_ID = "0100EB702342C000";
+    private const string LG_S_ID = "01002B5023434000";
+    private const string FR_F_ID = "01004B3023412000";
+    private const string LG_F_ID = "010087C02342E000";
+    private const string FR_D_ID = "01007F8023416000";
+    private const string LG_D_ID = "0100FD6023430000";
+    private const string FR_I_ID = "010092302342A000";
+    private const string LG_I_ID = "01005C7023432000";
+    private const string FR_J_ID = "01006FA0233F8000";
+    private const string LG_J_ID = "0100F1E0233FA000";
     private static readonly Dictionary<string, LiveHeXVersion[]> SupportedTitleVersions = new()
     {
         { LetsGoPikachu_ID, [LGPE_v102] },
@@ -40,6 +51,18 @@ public abstract class InjectionBase
         { Scarlet_ID, [SV_v101, SV_v110, SV_v120, SV_v130, SV_v131, SV_v132, SV_v201, SV_v202, SV_v300, SV_v301, SV_v400] },
         { Violet_ID,  [SV_v101, SV_v110, SV_v120, SV_v130, SV_v131, SV_v132, SV_v201, SV_v202, SV_v300, SV_v301, SV_v400] },
         { ZA_ID, [ZA_v101, ZA_v102, ZA_v103, ZA_v200, ZA_v201] },
+        { FR_E_ID, [FRLG_E_v100] },
+        { LG_E_ID, [FRLG_E_v100] },
+        { FR_S_ID, [FRLG_S_v100] },
+        { LG_S_ID, [FRLG_S_v100] },
+        { FR_F_ID, [FRLG_F_v100] },
+        { LG_F_ID, [FRLG_F_v100] },
+        { FR_D_ID, [FRLG_D_v100] },
+        { LG_D_ID, [FRLG_D_v100] },
+        { FR_I_ID, [FRLG_I_v100] },
+        { LG_I_ID, [FRLG_I_v100] },
+        { FR_J_ID, [FRLG_J_v100] },
+        { LG_J_ID, [FRLG_J_v100] },
     };
 
     public virtual Dictionary<string, string> SpecialBlocks { get; } = [];
@@ -54,7 +77,8 @@ public abstract class InjectionBase
 
         if (LPPointer.SupportedVersions.Contains(version))
             return new LPPointer();
-
+        if (LPFRLG.SupportedVersions.Contains(version))
+            return new LPFRLG();
         if (!LPBasic.SupportedVersions.Contains(version))
             throw new ArgumentOutOfRangeException(nameof(version), version, $"Unknown {nameof(LiveHeXVersion)}.");
 
@@ -70,7 +94,7 @@ public abstract class InjectionBase
     public virtual void SendSlot(PokeSysBotMini psb, ReadOnlySpan<byte> data, int box, int slot) { }
 
     public virtual void WriteBlocksFromSAV(PokeSysBotMini psb, string block, SaveFile sav) { }
-
+    public virtual void WriteBlocksFromStringSAV(PokeSysBotMini psb, string block, SaveFile sav, Span<byte> data) { }
     public virtual void WriteBlockFromString(PokeSysBotMini psb, string block, ReadOnlySpan<byte> data, object sb) { }
 
     public virtual bool ReadBlockFromString(PokeSysBotMini psb, SaveFile sav, string block, out List<byte[]>? read)
@@ -81,6 +105,7 @@ public abstract class InjectionBase
 
     public static bool SaveCompatibleWithTitle(SaveFile sav, string titleID) => sav switch
     {
+        SAV3FRLG when titleID is FR_D_ID or FR_E_ID or FR_F_ID or FR_I_ID or FR_J_ID or FR_S_ID or LG_D_ID or LG_E_ID or LG_F_ID or LG_I_ID or LG_J_ID or LG_S_ID => true,
         SAV9ZA when titleID is ZA_ID => true,
         SAV9SV when titleID is Scarlet_ID or Violet_ID => true,
         SAV8LA when titleID is LegendsArceus_ID => true,

--- a/PKHeX.Core.Injection/LiveHeXOffsets/RamOffsets.cs
+++ b/PKHeX.Core.Injection/LiveHeXOffsets/RamOffsets.cs
@@ -6,6 +6,7 @@ public static class RamOffsets
 {
     public static LiveHeXVersion[] GetValidVersions(SaveFile sf) => sf switch
     {
+        SAV3FRLG => [FRLG_E_v100, FRLG_S_v100, FRLG_F_v100, FRLG_D_v100, FRLG_I_v100, FRLG_J_v100],
         SAV9ZA => [ZA_v101, ZA_v102, ZA_v103, ZA_v200, ZA_v201],
         SAV9SV =>
         [
@@ -32,6 +33,7 @@ public static class RamOffsets
 
     public static bool IsLiveHeXSupported(SaveFile sav) => sav switch
     {
+        SAV3FRLG => true,
         SAV9ZA => true,
         SAV9SV => true,
         SAV8LA => true,
@@ -76,6 +78,7 @@ public static class RamOffsets
 
     public static int GetSlotSize(LiveHeXVersion lv) => lv switch
     {
+        >= FRLG_E_v100 => 80,
         >= ZA_v101 and <= ZA_v201 => 408,
         LA_v111 => 360,
         LA_v102 => 360,
@@ -152,6 +155,12 @@ public static class RamOffsets
         SM_v120 => true,
         ORAS_v140 => true,
         XY_v150 => true,
+        FRLG_D_v100 => true,
+        FRLG_E_v100 => true,
+        FRLG_F_v100 => true,
+        FRLG_I_v100 => true,
+        FRLG_J_v100 => true,
+        FRLG_S_v100 => true,
         _ => false,
     };
 

--- a/PKHeX.Core.Injection/Protocols/LPFRLG.cs
+++ b/PKHeX.Core.Injection/Protocols/LPFRLG.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using static PKHeX.Core.Injection.LiveHeXVersion;
+
+namespace PKHeX.Core.Injection;
+
+public sealed class LPFRLG : InjectionBase
+{
+    public static ReadOnlySpan<LiveHeXVersion> SupportedVersions => [ FRLG_D_v100, FRLG_E_v100, FRLG_F_v100, FRLG_I_v100, FRLG_J_v100, FRLG_S_v100];
+    private const uint fakeHeap = 0x2020000;
+    private const uint startingOffset = 0x1208000;
+    public static uint securitykey = 0;
+    public static uint GetB1S1Offset(LiveHeXVersion lv) => lv switch 
+    { 
+        LiveHeXVersion.FRLG_E_v100 => 0xBD68D2E0,
+        LiveHeXVersion.FRLG_I_v100 => 0xBD68D230,
+    };
+    public uint GetLargeBlockOffset(LiveHeXVersion lv) => lv switch
+    {
+        LiveHeXVersion.FRLG_E_v100 => 0xBD68D2D8,
+        LiveHeXVersion.FRLG_I_v100 => 0xBD68D228,
+        _ => 0,
+    };
+    public uint GetSmallBlockOffset(LiveHeXVersion lv) => lv switch
+    {
+        LiveHeXVersion.FRLG_E_v100 => 0xBD68D2DC,
+        LiveHeXVersion.FRLG_I_v100 => 0xBD68D22C,
+        _ => 0,
+    };
+    public override Span<byte> ReadBox(PokeSysBotMini psb, int box, int len, List<byte[]> allpkm)
+    {
+        var lv = psb.Version;
+        var boxoffbytes = psb.com.ReadBytes(GetB1S1Offset(lv), 4);
+        var boxoff = BitConverter.ToUInt32(boxoffbytes);
+        boxoff -= fakeHeap;
+        boxoff += startingOffset;
+        var boxsize = RamOffsets.GetSlotCount(lv) * RamOffsets.GetSlotSize(lv);
+        var boxstart = boxoff + (ulong)(box * boxsize);
+        return psb.com.ReadBytes(boxstart + 4, boxsize);
+    }
+    public override Span<byte> ReadSlot(PokeSysBotMini psb, int box, int slot)
+    {
+        var lv = psb.Version;
+        var slotsize = RamOffsets.GetSlotSize(lv);
+        var boxoffbytes = psb.com.ReadBytes(GetB1S1Offset(lv), 4);
+        var boxoff = BitConverter.ToUInt32(boxoffbytes);
+        boxoff -= fakeHeap;
+        boxoff += startingOffset;
+        var slotstart = boxoff + (ulong)(slot * slotsize);
+        return psb.com.ReadBytes(slotstart + 4, slotsize);
+    }
+    public override void SendSlot(PokeSysBotMini psb, ReadOnlySpan<byte> data, int box, int slot)
+    {
+        var lv = psb.Version;
+        var slotsize = RamOffsets.GetSlotSize(lv);
+        var boxoffbytes = psb.com.ReadBytes(GetB1S1Offset(lv), 4);
+        var boxoff = BitConverter.ToUInt32(boxoffbytes);
+        boxoff -= fakeHeap;
+        boxoff += startingOffset;
+        var slotstart = boxoff + (ulong)(slot * slotsize);
+        psb.com.WriteBytes(data, slotstart + 4);
+    }
+    public override void SendBox(PokeSysBotMini psb, ReadOnlySpan<byte> boxData, int box)
+    {
+        var lv = psb.Version;
+        var boxoffbytes = psb.com.ReadBytes(GetB1S1Offset(lv), 4);
+        var boxoff = BitConverter.ToUInt32(boxoffbytes);
+        boxoff -= fakeHeap;
+        boxoff += startingOffset;
+        var boxsize = RamOffsets.GetSlotCount(lv) * RamOffsets.GetSlotSize(lv);
+        var boxstart = boxoff + (ulong)(box * boxsize);
+        psb.com.WriteBytes(boxData, boxstart + 4);
+    }
+    public override bool ReadBlockFromString(PokeSysBotMini psb, SaveFile sav, string block, out List<byte[]>? read)
+    {
+        read = null;
+        try
+        {
+            var offsets = SCBlocks[psb.Version].Where(z => z.Display == block).First();
+            var props = sav.GetType().GetProperty(block) ?? throw new Exception($"{block} not found");
+            var blockoffbytes = offsets.Name == "Large" ? psb.com.ReadBytes(GetLargeBlockOffset(psb.Version), 4) : psb.com.ReadBytes(GetSmallBlockOffset(psb.Version), 4);
+            var blockoff = BitConverter.ToUInt32(blockoffbytes);
+            blockoff -= fakeHeap;
+            blockoff += startingOffset;
+            blockoff += (uint)offsets.Offset;
+            var ram = psb.com.ReadBytes(blockoff, Marshal.SizeOf(props.PropertyType));
+            var val = ConvertValue(props, ram);
+            if (offsets.IsSecured)
+                val = (uint)val ^ ((SAV3FRLG)sav).SecurityKey;
+            props.SetValue(sav, val);
+            read = [ram.ToArray()];
+            return true;
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e.StackTrace);
+            return false;
+        }
+    }
+    public override void WriteBlocksFromSAV(PokeSysBotMini psb, string block, SaveFile sav)
+    {
+        var props = sav.GetType().GetProperty(block) ?? throw new Exception($"{block} not found");
+        var offsets = SCBlocks[psb.Version].Where(z => z.Display == block).First();
+        var data = props.GetValue(sav);
+        if (offsets.IsSecured)
+            data = (uint)data ^ ((SAV3FRLG)sav).SecurityKey;
+        var blockoffbytes = offsets.Name == "Large" ? psb.com.ReadBytes(GetLargeBlockOffset(psb.Version), 4) : psb.com.ReadBytes(GetSmallBlockOffset(psb.Version), 4);
+        var blockoff = BitConverter.ToUInt32(blockoffbytes);
+        blockoff -= fakeHeap;
+        blockoff += startingOffset;
+        blockoff += (uint)offsets.Offset;
+        psb.com.WriteBytes(BitConverter.GetBytes((uint)data), blockoff);
+    }
+    public object ConvertValue(PropertyInfo info, Span<byte> bytes)
+    {
+        var t = info.PropertyType;
+        if (t == typeof(UInt16))
+            return BitConverter.ToUInt16(bytes);
+        else if (t == typeof(UInt32))
+            return BitConverter.ToUInt32(bytes);
+        else if (t == typeof(UInt64))
+            return BitConverter.ToUInt64(bytes);
+        else
+            BitConverter.ToUInt128(bytes);
+        throw new InvalidEnumArgumentException($"Unsupported type {t} for {info.Name}");
+    }
+    private static BlockData Get(uint offset, string name, string display, SCTypeCode type) => new()
+    {
+        Name = name,
+        Display = display,
+        Type = type,
+        Offset = offset,
+    };
+    private static BlockData Get(uint offset, string name, string display, bool secured) => new()
+    {
+        Name = name,
+        Display = display,
+        Offset = offset,
+        IsSecured = secured,
+    };
+    private static BlockData Get(uint offset, string name, string display) => new()
+    {
+        Name = name,
+        Display = display,
+        Offset = offset,
+    };
+    public static readonly BlockData[] Blocks_FRLG = new[]
+    {
+        Get(0x290, "Large", "Money", true),
+    };
+    public static readonly Dictionary<LiveHeXVersion, BlockData[]> SCBlocks = new()
+    {
+        { FRLG_E_v100, Blocks_FRLG  },
+        { FRLG_I_v100, Blocks_FRLG },
+    };
+}
+

--- a/PKHeX.Core.Injection/Protocols/LPFRLG.cs
+++ b/PKHeX.Core.Injection/Protocols/LPFRLG.cs
@@ -21,17 +21,28 @@ public sealed class LPFRLG : InjectionBase
     { 
         LiveHeXVersion.FRLG_E_v100 => 0xBD68D2E0,
         LiveHeXVersion.FRLG_I_v100 => 0xBD68D230,
+        LiveHeXVersion.FRLG_D_v100 => 0xBD68D230,
+        LiveHeXVersion.FRLG_S_v100 => 0xBD68D230,
+        LiveHeXVersion.FRLG_F_v100 => 0xBD68D230,
+        LiveHeXVersion.FRLG_J_v100 => 0xBD68D240,
     };
     public uint GetLargeBlockOffset(LiveHeXVersion lv) => lv switch
     {
         LiveHeXVersion.FRLG_E_v100 => 0xBD68D2D8,
         LiveHeXVersion.FRLG_I_v100 => 0xBD68D228,
-        _ => 0,
+        LiveHeXVersion.FRLG_D_v100 => 0xBD68D228,
+        LiveHeXVersion.FRLG_S_v100 => 0xBD68D228,
+        LiveHeXVersion.FRLG_F_v100 => 0xBD68D228,
+        LiveHeXVersion.FRLG_J_v100 => 0xBD68D238,
     };
     public uint GetSmallBlockOffset(LiveHeXVersion lv) => lv switch
     {
         LiveHeXVersion.FRLG_E_v100 => 0xBD68D2DC,
         LiveHeXVersion.FRLG_I_v100 => 0xBD68D22C,
+        LiveHeXVersion.FRLG_D_v100 => 0xBD68D22C,
+        LiveHeXVersion.FRLG_S_v100 => 0xBD68D22C,
+        LiveHeXVersion.FRLG_F_v100 => 0xBD68D22C,
+        LiveHeXVersion.FRLG_J_v100 => 0xBD68D23C,
         _ => 0,
     };
     public override Span<byte> ReadBox(PokeSysBotMini psb, int box, int len, List<byte[]> allpkm)
@@ -83,18 +94,22 @@ public sealed class LPFRLG : InjectionBase
         read = null;
         try
         {
-            var offsets = SCBlocks[psb.Version].Where(z => z.Display == block).First();
+            var offsets = SCBlocks[psb.Version].Where(z => z.Display == (block == "Large" ? "Items" : block)).First();
             var props = sav.GetType().GetProperty(block) ?? throw new Exception($"{block} not found");
             var blockoffbytes = offsets.Name == "Large" ? psb.com.ReadBytes(GetLargeBlockOffset(psb.Version), 4) : psb.com.ReadBytes(GetSmallBlockOffset(psb.Version), 4);
             var blockoff = BitConverter.ToUInt32(blockoffbytes);
             blockoff -= fakeHeap;
             blockoff += startingOffset;
             blockoff += (uint)offsets.Offset;
-            var ram = psb.com.ReadBytes(blockoff, Marshal.SizeOf(props.PropertyType));
+            var size = offsets.Name == "Large" ? 0x3e00 : Marshal.SizeOf(props.PropertyType);
+            var ram = psb.com.ReadBytes(blockoff, size);
             var val = ConvertValue(props, ram);
             if (offsets.IsSecured)
                 val = (uint)val ^ ((SAV3FRLG)sav).SecurityKey;
-            props.SetValue(sav, val);
+            if (offsets.Display == "Large")
+                ram.CopyTo(((SAV3)sav).Large);
+            else
+                props.SetValue(sav, val);
             read = [ram.ToArray()];
             return true;
         }
@@ -107,8 +122,8 @@ public sealed class LPFRLG : InjectionBase
     public override void WriteBlocksFromSAV(PokeSysBotMini psb, string block, SaveFile sav)
     {
         var props = sav.GetType().GetProperty(block) ?? throw new Exception($"{block} not found");
-        var offsets = SCBlocks[psb.Version].Where(z => z.Display == block).First();
-        var data = props.GetValue(sav);
+        var offsets = SCBlocks[psb.Version].Where(z => z.Display == (block == "Large" ? "Items" : block)).First();
+        var data = block == "Large" ? ((SAV3)sav).Large.ToArray() : props.GetValue(sav);
         if (offsets.IsSecured)
             data = (uint)data ^ ((SAV3FRLG)sav).SecurityKey;
         var blockoffbytes = offsets.Name == "Large" ? psb.com.ReadBytes(GetLargeBlockOffset(psb.Version), 4) : psb.com.ReadBytes(GetSmallBlockOffset(psb.Version), 4);
@@ -116,7 +131,7 @@ public sealed class LPFRLG : InjectionBase
         blockoff -= fakeHeap;
         blockoff += startingOffset;
         blockoff += (uint)offsets.Offset;
-        psb.com.WriteBytes(BitConverter.GetBytes((uint)data), blockoff);
+        psb.com.WriteBytes(block == "Large" ? (byte[])data : BitConverter.GetBytes((uint)data), blockoff);
     }
     public object ConvertValue(PropertyInfo info, Span<byte> bytes)
     {
@@ -127,8 +142,10 @@ public sealed class LPFRLG : InjectionBase
             return BitConverter.ToUInt32(bytes);
         else if (t == typeof(UInt64))
             return BitConverter.ToUInt64(bytes);
+        else if (t == typeof(UInt128))
+            return BitConverter.ToUInt128(bytes);
         else
-            BitConverter.ToUInt128(bytes);
+            return bytes.ToArray();
         throw new InvalidEnumArgumentException($"Unsupported type {t} for {info.Name}");
     }
     private static BlockData Get(uint offset, string name, string display, SCTypeCode type) => new()
@@ -154,11 +171,18 @@ public sealed class LPFRLG : InjectionBase
     public static readonly BlockData[] Blocks_FRLG = new[]
     {
         Get(0x290, "Large", "Money", true),
+        Get(0x294, "Large", "Coin", true),
+        Get(0, "Large", "Items"),
+        Get(0xF20, "Small", "SecurityKey")
     };
     public static readonly Dictionary<LiveHeXVersion, BlockData[]> SCBlocks = new()
     {
         { FRLG_E_v100, Blocks_FRLG  },
         { FRLG_I_v100, Blocks_FRLG },
+    };
+    public override Dictionary<string, string> SpecialBlocks { get; } = new()
+    {
+        { "Large", "B_OpenItemPouch_Click" },
     };
 }
 


### PR DESCRIPTION
Adds Livehex compatibility to FRLG.
This requires a full save file to be loaded to make edits to certain blocks. If PKHeX crashes when you go to edit a block, this means you need to load a save file. 
Currently Items is the only thing that requires this. 